### PR TITLE
Fix running 'make': upgrade to infer-annotations-1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ c_test: c
 java: transpile_all src/java
 	@if [ ! -f lib/junit4.jar ]; then mkdir lib/; wget -O lib/junit4.jar http://search.maven.org/remotecontent?filepath=junit/junit/4.10/junit-4.10.jar; fi
 	@if [ ! -f lib/jsr305.jar ]; then mkdir lib/; wget -O lib/jsr305.jar http://search.maven.org/remotecontent?filepath=net/sourceforge/findbugs/jsr305/1.3.7/jsr305-1.3.7.jar; fi
-	@if [ ! -f lib/infer-annotations-1.3.jar ]; then mkdir lib/; wget -O lib/infer-annotations-1.3.jar https://github.com/facebook/buck/raw/master/third-party/java/infer-annotations/infer-annotations-1.3.jar; fi
-	@javac -cp ./lib/junit4.jar:./lib/jsr305.jar:./lib/infer-annotations-1.3.jar -sourcepath ./src/java/src:./src/java/tests src/java/tests/com/facebook/csslayout/*.java
+	@if [ ! -f lib/infer-annotations-1.4.jar ]; then mkdir lib/; wget -O lib/infer-annotations-1.4.jar https://github.com/facebook/buck/raw/master/third-party/java/infer-annotations/infer-annotations-1.4.jar; fi
+	@javac -cp ./lib/junit4.jar:./lib/jsr305.jar:./lib/infer-annotations-1.4.jar -sourcepath ./src/java/src:./src/java/tests src/java/tests/com/facebook/csslayout/*.java
 
 java_test: java
-	@java -cp ./src/java/src:./src/java/tests:./lib/junit4.jar:./lib/infer-annotations-1.3.jar org.junit.runner.JUnitCore \
+	@java -cp ./src/java/src:./src/java/tests:./lib/junit4.jar:./lib/infer-annotations-1.4.jar org.junit.runner.JUnitCore \
       com.facebook.csslayout.LayoutEngineTest \
       com.facebook.csslayout.LayoutCachingTest \
       com.facebook.csslayout.CSSNodeTest


### PR DESCRIPTION
It seems that 'buck' tool got infer-annotations upgraded from 1.3 to 1.4, so typing 'make' in console gave a 404 error while trying to build a 'java' target.
Fixed that by updating version to 1.4, now tests run and pass.