### PR TITLE
computeLayout now adds layout, children and style properties as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,48 @@ Usage
 
 A single function `computeLayout` is exposed and
  - takes a tree of nodes: `{ style: { ... }, children: [ nodes ] }`
- - returns a tree of rectangles: `{ width: ..., height: ..., top: ..., left: ..., children: [ rects ] }`
+ - updates the tree adding layout information: `layout: { width: ..., height: ..., top: ..., left: ... }`
 
 For example,
 
 ```javascript
-computeLayout(
-  {style: {padding: 50}, children: [
+var nodes = {
+  style: {padding: 50}, children: [
     {style: {padding: 10, alignSelf: 'stretch'}}
-  ]}
-);
+  ]
+};
+
+computeLayout(nodes);
+
+JSON.stringify(nodes, null, 2);
+
 // =>
-{width: 120, height: 120, top: 0, left: 0, children: [
-  {width: 20, height: 20, top: 50, left: 50}
-]}
+"{
+  "style": {
+    "padding": 50
+  },
+  "children": [
+    {
+      "style": {
+        "padding": 10,
+        "alignSelf": "stretch"
+      },
+      "layout": {
+        "width": 20,
+        "height": 20,
+        "top": 50,
+        "left": 50
+      },
+      "children": []
+    }
+  ],
+  "layout": {
+    "width": 120,
+    "height": 120,
+    "top": 0,
+    "left": 0
+  }
+}"
 ```
 
 To run the tests

--- a/src/Layout-test-utils.js
+++ b/src/Layout-test-utils.js
@@ -129,23 +129,6 @@ var layoutTestUtils = (function() {
   }
 
   function computeCSSLayout(rootNode) {
-    function fillNodes(node) {
-      node.layout = {
-        width: undefined,
-        height: undefined,
-        top: 0,
-        left: 0
-      };
-      if (!node.style) {
-        node.style = {};
-      }
-
-      if (!node.children || node.style.measure) {
-        node.children = [];
-      }
-      node.children.forEach(fillNodes);
-    }
-
     function extractNodes(node) {
       var layout = node.layout;
       delete node.layout;
@@ -157,7 +140,6 @@ var layoutTestUtils = (function() {
       return layout;
     }
 
-    fillNodes(rootNode);
     realComputeLayout(rootNode);
     return roundLayout(extractNodes(rootNode));
   }

--- a/src/Layout.c
+++ b/src/Layout.c
@@ -306,6 +306,11 @@ static float getPosition(css_node_t *node, css_position_t position) {
   return 0;
 }
 
+static void prepareNode(css_node_t *node) {
+  // no-op, this function is used within JavaScript to ensure
+  // all nodes have the correct structure
+}
+
 // When the user specifically sets a value for width or height
 static void setDimensionFromStyle(css_node_t *node, css_flex_direction_t axis) {
   // The parent already computed us a width or height. We just skip it
@@ -340,6 +345,8 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
   css_flex_direction_t crossAxis = mainAxis == CSS_FLEX_DIRECTION_ROW ?
     CSS_FLEX_DIRECTION_COLUMN :
     CSS_FLEX_DIRECTION_ROW;
+
+  prepareNode(node);
 
   // Handle width and height style attributes
   setDimensionFromStyle(node, mainAxis);
@@ -399,6 +406,7 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
         getPositionType(child) == CSS_POSITION_RELATIVE &&
         !isUndefined(node->layout.dimensions[dim[crossAxis]]) &&
         !isDimDefined(child, crossAxis)) {
+      prepareNode(child);
       child->layout.dimensions[dim[crossAxis]] = fmaxf(
         node->layout.dimensions[dim[crossAxis]] -
           getPaddingAndBorderAxis(node, crossAxis) -
@@ -415,6 +423,7 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
             !isDimDefined(child, axis) &&
             isPosDefined(child, leading[axis]) &&
             isPosDefined(child, trailing[axis])) {
+          prepareNode(child);
           child->layout.dimensions[dim[axis]] = fmaxf(
             node->layout.dimensions[dim[axis]] -
             getPaddingAndBorderAxis(node, axis) -
@@ -438,11 +447,12 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
   // We want to execute the next two loops one per line with flex-wrap
   int startLine = 0;
   int endLine = 0;
-  int nextLine = 0;
+  int nextOffset = 0;
+  int alreadyComputedNextLayout = 0;
   // We aggregate the total dimensions of the container in those two variables
   float linesCrossDim = 0;
   float linesMainDim = 0;
-  while (endLine != node->children_count) {
+  while (endLine < node->children_count) {
     // <Loop A> Layout non flexible children and count children by type
 
     // mainContentDim is accumulation of the dimensions and margin of all the
@@ -486,7 +496,7 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
         }
 
         // This is the main recursive call. We layout non flexible children.
-        if (nextLine == 0) {
+        if (alreadyComputedNextLayout == 0) {
           layoutNode(child, maxWidth);
         }
 
@@ -502,11 +512,14 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
       // The element we are about to add would make us go to the next line
       if (isFlexWrap(node) &&
           !isUndefined(node->layout.dimensions[dim[mainAxis]]) &&
-          mainContentDim + nextContentDim > definedMainDim) {
-        nextLine = i + 1;
+          mainContentDim + nextContentDim > definedMainDim &&
+          // If there's only one element, then it's bigger than the content
+          // and needs its own line
+          i != startLine) {
+        alreadyComputedNextLayout = 1;
         break;
       }
-      nextLine = 0;
+      alreadyComputedNextLayout = 0;
       mainContentDim += nextContentDim;
       endLine = i + 1;
     }
@@ -543,6 +556,7 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
       for (int i = startLine; i < endLine; ++i) {
         css_node_t* child = node->get_child(node->context, i);
         if (isFlex(child)) {
+          prepareNode(child);
           // At this point we know the final size of the element in the main
           // dimension
           child->layout.dimensions[dim[mainAxis]] = flexibleMainDim * getFlex(child) +

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -9,26 +9,23 @@
 
 var computeLayout = (function() {
 
-  // Ensures that all nodes have layoutm style and children properties. This simplifies
+  // Ensures that all nodes have layout, style and children properties. This simplifies
   // the layout algorithm in that it can assume a uniform structure
-  function prepareNodes(node) {
-    if (!node.layout) {
-      node.layout = {
+  function prepareNode(newNode) {
+    if (!newNode.layout) {
+      newNode.layout = {
         width: undefined,
         height: undefined,
         top: 0,
         left: 0
       };
     }
-    if (!node.style) {
-      node.style = {};
+    if (!newNode.style) {
+      newNode.style = {};
     }
-
-    if (!node.children || node.style.measure) {
-      node.children = [];
+    if (!newNode.children || newNode.style.measure) {
+      newNode.children = [];
     }
-
-    node.children.forEach(prepareNodes);
   }
 
   function capitalizeFirst(str) {
@@ -230,11 +227,13 @@ var computeLayout = (function() {
   var CSS_POSITION_RELATIVE = 'relative';
   var CSS_POSITION_ABSOLUTE = 'absolute';
 
-  function layoutNode(node, parentMaxWidth) {
+  return function layoutNode(node, parentMaxWidth) {
     var/*css_flex_direction_t*/ mainAxis = getFlexDirection(node);
     var/*css_flex_direction_t*/ crossAxis = mainAxis === CSS_FLEX_DIRECTION_ROW ?
       CSS_FLEX_DIRECTION_COLUMN :
       CSS_FLEX_DIRECTION_ROW;
+
+    prepareNode(node);
 
     // Handle width and height style attributes
     setDimensionFromStyle(node, mainAxis);
@@ -294,6 +293,7 @@ var computeLayout = (function() {
           getPositionType(child) === CSS_POSITION_RELATIVE &&
           !isUndefined(node.layout[dim[crossAxis]]) &&
           !isDimDefined(child, crossAxis)) {
+        prepareNode(child);
         child.layout[dim[crossAxis]] = fmaxf(
           node.layout[dim[crossAxis]] -
             getPaddingAndBorderAxis(node, crossAxis) -
@@ -310,6 +310,7 @@ var computeLayout = (function() {
               !isDimDefined(child, axis) &&
               isPosDefined(child, leading[axis]) &&
               isPosDefined(child, trailing[axis])) {
+            prepareNode(child);
             child.layout[dim[axis]] = fmaxf(
               node.layout[dim[axis]] -
               getPaddingAndBorderAxis(node, axis) -
@@ -442,6 +443,7 @@ var computeLayout = (function() {
         for (var/*int*/ i = startLine; i < endLine; ++i) {
           var/*css_node_t**/ child = node.children[i];
           if (isFlex(child)) {
+            prepareNode(child);
             // At this point we know the final size of the element in the main
             // dimension
             child.layout[dim[mainAxis]] = flexibleMainDim * getFlex(child) +
@@ -673,11 +675,6 @@ var computeLayout = (function() {
       }
     }
   };
-
-  return function performLayout(node, parentMaxWidth) {
-    prepareNodes(node);
-    layoutNode(node, parentMaxWidth);
-  }
 })();
 
 if (typeof module === 'object') {

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -9,6 +9,28 @@
 
 var computeLayout = (function() {
 
+  // Ensures that all nodes have layoutm style and children properties. This simplifies
+  // the layout algorithm in that it can assume a uniform structure
+  function prepareNodes(node) {
+    if (!node.layout) {
+      node.layout = {
+        width: undefined,
+        height: undefined,
+        top: 0,
+        left: 0
+      };
+    }
+    if (!node.style) {
+      node.style = {};
+    }
+
+    if (!node.children || node.style.measure) {
+      node.children = [];
+    }
+
+    node.children.forEach(prepareNodes);
+  }
+
   function capitalizeFirst(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
@@ -208,7 +230,7 @@ var computeLayout = (function() {
   var CSS_POSITION_RELATIVE = 'relative';
   var CSS_POSITION_ABSOLUTE = 'absolute';
 
-  return function layoutNode(node, parentMaxWidth) {
+  function layoutNode(node, parentMaxWidth) {
     var/*css_flex_direction_t*/ mainAxis = getFlexDirection(node);
     var/*css_flex_direction_t*/ crossAxis = mainAxis === CSS_FLEX_DIRECTION_ROW ?
       CSS_FLEX_DIRECTION_COLUMN :
@@ -651,6 +673,11 @@ var computeLayout = (function() {
       }
     }
   };
+
+  return function performLayout(node, parentMaxWidth) {
+    prepareNodes(node);
+    layoutNode(node, parentMaxWidth);
+  }
 })();
 
 if (typeof module === 'object') {

--- a/src/__tests__/Layout-test.js
+++ b/src/__tests__/Layout-test.js
@@ -14,6 +14,22 @@ var texts = layoutTestUtils.texts;
 var textSizes = layoutTestUtils.textSizes;
 
 describe('Layout', function() {
+
+  it('should accomodate nodes that already have layout and children properties', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000}, children: [
+        {style: {width: 500, height: 500}},
+        {style: {width: 250, height: 250}, layout: { width: undefined, height: undefined, top: 0, left: 0}},
+        {style: {width: 125, height: 125}, children: []}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 500, height: 500, top: 0, left: 0},
+        {width: 250, height: 250, top: 500, left: 0},
+        {width: 125, height: 125, top: 750, left: 0}
+      ]}
+    );
+  });
+
   it('should layout a single node with width and height', function() {
     testLayout({
       style: {width: 100, height: 200}

--- a/src/java/src/com/facebook/csslayout/LayoutEngine.java
+++ b/src/java/src/com/facebook/csslayout/LayoutEngine.java
@@ -247,6 +247,11 @@ public class LayoutEngine {
     return node.isMeasureDefined();
   }
 
+  private static void prepareNode(CSSNode node) {
+    // no-op, this function is used within JavaScript to ensure
+    // all nodes have the correct structure
+  }
+
   private static float getDimWithMargin(CSSNode node, CSSFlexDirection axis) {
     return getLayoutDimension(node, getDim(axis)) +
         getMargin(node, getLeading(axis)) +
@@ -287,6 +292,8 @@ public class LayoutEngine {
     CSSFlexDirection crossAxis = mainAxis == CSSFlexDirection.ROW ?
       CSSFlexDirection.COLUMN :
       CSSFlexDirection.ROW;
+  
+    prepareNode(node);
   
     // Handle width and height style attributes
     setDimensionFromStyle(node, mainAxis);
@@ -345,6 +352,7 @@ public class LayoutEngine {
           getPositionType(child) == CSSPositionType.RELATIVE &&
           !CSSConstants.isUndefined(getLayoutDimension(node, getDim(crossAxis))) &&
           !isDimDefined(child, crossAxis)) {
+        prepareNode(child);
         setLayoutDimension(child, getDim(crossAxis), Math.max(
           getLayoutDimension(node, getDim(crossAxis)) -
             getPaddingAndBorderAxis(node, crossAxis) -
@@ -361,6 +369,7 @@ public class LayoutEngine {
               !isDimDefined(child, axis) &&
               isPosDefined(child, getLeading(axis)) &&
               isPosDefined(child, getTrailing(axis))) {
+            prepareNode(child);
             setLayoutDimension(child, getDim(axis), Math.max(
               getLayoutDimension(node, getDim(axis)) -
               getPaddingAndBorderAxis(node, axis) -
@@ -493,6 +502,7 @@ public class LayoutEngine {
         for (int i = startLine; i < endLine; ++i) {
           CSSNode child = node.getChildAt(i);
           if (isFlex(child)) {
+            prepareNode(child);
             // At this point we know the final size of the element in the main
             // dimension
             setLayoutDimension(child, getDim(mainAxis), flexibleMainDim * getFlex(child) +


### PR DESCRIPTION
Closes #24 

I've removed `fillNodes` from the unite tests, moving this logic to `prepareNodes` within `computeLayout`. There's a unit test that ensures backward compatibility.

I've also updated the README to provide a better description of the JS API.

