### PR TITLE
Fixed preDefinedTextSizes for Chrome Canary 42.0.2295.0

### DIFF
--- a/src/Layout-test-utils.js
+++ b/src/Layout-test-utils.js
@@ -357,11 +357,11 @@ var layoutTestUtils = (function() {
   };
 
   var preDefinedTextSizes = {
-    smallWidth: 34.671875,
+    smallWidth: 34.65625,
     smallHeight: 16,
     bigWidth: 172.421875,
     bigHeight: 32,
-    bigMinWidth: 100.453125
+    bigMinWidth: 100.4375
   };
 
   var textSizes;


### PR DESCRIPTION
Updated the default text size so that "RunLayoutTests.html" will pass.

However, "RunLayoutRandomTests.html" is still failing in various random layout tests.