### PR TITLE
Fix firefox iframe timing issue in test runners, fixes #25

### DIFF
--- a/src/Layout-test-utils.js
+++ b/src/Layout-test-utils.js
@@ -44,47 +44,60 @@ var layoutTestUtils = (function() {
     };
   }
 
+  function renderIframe() {
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    return iframe;
+  }
+
   var cachedIframe;
   function getIframe() {
     if (cachedIframe) {
       return cachedIframe;
     }
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
+
     var doc = iframe.contentDocument;
 
-    var style = document.createElement('style');
-    style.innerText = (function() {/*
-      body, div {
-        box-sizing: border-box;
-        border: 0 solid black;
-        position: relative;
+    if(doc.readyState === 'complete') {
+      var style = document.createElement('style');
+      style.textContent = (function() {/*
+        body, div {
+          box-sizing: border-box;
+          border: 0 solid black;
+          position: relative;
 
-        display: flex;
-        display: -webkit-flex;
-        flex-direction: column;
-        -webkit-flex-direction: column;
-        align-items: stretch;
-        -webkit-align-items: stretch;
-        justify-content: flex-start;
-        -webkit-justify-content: flex-start;
-        flex-shrink: 0;
-        -webkit-flex-shrink: 0;
+          display: flex;
+          display: -webkit-flex;
+          flex-direction: column;
+          -webkit-flex-direction: column;
+          align-items: stretch;
+          -webkit-align-items: stretch;
+          justify-content: flex-start;
+          -webkit-justify-content: flex-start;
+          flex-shrink: 0;
+          -webkit-flex-shrink: 0;
 
-        margin: 0;
-        padding: 0;
-      }
+          margin: 0;
+          padding: 0;
+        }
 
-      hack to ignore three hundred px width of the body {}
-      body > div {
-        align-self: flex-start;
-      }
-    */} + '').slice(15, -4);
-    doc.head.appendChild(style);
-    cachedIframe = iframe;
-    return iframe;
+        hack to ignore three hundred px width of the body {}
+        body > div {
+          align-self: flex-start;
+        }
+      */} + '').slice(15, -4);
+      doc.head.appendChild(style);
+      cachedIframe = iframe;
+      return iframe;
+    } else {
+      setTimeout(getIframe, 0);
+    }
   }
 
+  if (typeof window !== 'undefined') {
+    var iframe = renderIframe();
+    getIframe();
+  }
 
   if (typeof computeLayout === 'function') {
     var realComputeLayout = computeLayout;


### PR DESCRIPTION
All browsers except chrome have timing issues when dynamically creating and injecting content inside an iframe, see [blog post](https://developer.zendesk.com/blog/2014/05/13/rendering-to-iframes-in-react/) if you're interested in why. Boils down to waiting for the `readyState` to be `complete` before appending to the DOM.

All tests pass in Firefox except 2, not sure how to fix these so any help would be good.

![screen shot 2015-02-05 at 8 38 47 pm](https://cloud.githubusercontent.com/assets/143402/6058090/27035ee8-ad78-11e4-9ff6-078847bf68cc.png)

I also changed the use of `innerText` to `textContent` as Firefox refused to render the CSS string and in Chrome it added a bunch of `<br>` tags and somehow the CSS parser is forgiving enough to still work!

![screen shot 2015-02-05 at 8 44 35 pm](https://cloud.githubusercontent.com/assets/143402/6058121/765bf694-ad78-11e4-96ac-21050e1069e7.png)
