### PR TITLE
Add UMD

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -8,7 +8,6 @@
  */
 
 var computeLayout = (function() {
-
   function capitalizeFirst(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
@@ -653,7 +652,21 @@ var computeLayout = (function() {
   };
 })();
 
-if (typeof module === 'object') {
-  module.exports = computeLayout;
-}
-
+// UMD (Universal Module Definition)
+// See https://github.com/umdjs/umd for reference
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.returnExports = factory();
+  }
+}(this, function () {
+  return computeLayout;
+}));


### PR DESCRIPTION
Make it work...... everywhere!

Putting computeLayout in the IIFE right away broke the transpiler for me. Nevertheless, I think using an out of the box UMD pattern makes sense here. I don't see a reason why css-layout shouldn't be script loader agnostic.