### PR TITLE
Cleanup and extra tests for min/max support

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -204,13 +204,13 @@ var computeLayout = (function() {
 
   function boundAxis(node, axis, value) {
     var min = {
-      row: node.style['minWidth'],
-      column: node.style['minHeight']
+      row: node.style.minWidth,
+      column: node.style.minHeight
     }[axis];
 
     var max = {
-      row: node.style['maxWidth'],
-      column: node.style['maxHeight']
+      row: node.style.maxWidth,
+      column: node.style.maxHeight
     }[axis];
 
     var boundValue = value;

--- a/src/__tests__/Layout-test.c
+++ b/src/__tests__/Layout-test.c
@@ -4111,6 +4111,112 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 60;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 120;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should ignore flex size if fully max bound", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 120;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 120;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 120;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 120;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 240;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should ignore flex size if fully min bound", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.dimensions[CSS_WIDTH] = 300;
       node_0->style.dimensions[CSS_HEIGHT] = 200;
       init_css_node_children(node_0, 1);

--- a/src/__tests__/Layout-test.js
+++ b/src/__tests__/Layout-test.js
@@ -1302,7 +1302,7 @@ describe('Layout', function() {
 
   it('should override flex direction size with min bounds', function() {
     testLayout(
-      {style: {width: 300, height: 200, flexDirection:'row'}, children: [
+      {style: {width: 300, height: 200, flexDirection: 'row'}, children: [
         {style: {flex: 1}},
         {style: {flex: 1, minWidth: 200}},
         {style: {flex: 1}}
@@ -1332,7 +1332,7 @@ describe('Layout', function() {
 
   it('should override flex direction size with max bounds', function() {
     testLayout(
-      {style: {width: 300, height: 200, flexDirection:'row'}, children: [
+      {style: {width: 300, height: 200, flexDirection: 'row'}, children: [
         {style: {flex: 1}},
         {style: {flex: 1, maxWidth: 60}},
         {style: {flex: 1}}
@@ -1341,6 +1341,36 @@ describe('Layout', function() {
         {width: 120, height: 200, top: 0, left: 0},
         {width: 60, height: 200, top: 0, left: 120},
         {width: 120, height: 200, top: 0, left: 180}
+      ]}
+    );
+  });
+
+  it ('should ignore flex size if fully max bound', function() {
+    testLayout(
+      {style: {width: 300, height: 200, flexDirection: 'row'}, children: [
+        {style: {flex: 1, maxWidth: 60}},
+        {style: {flex: 1, maxWidth: 60}},
+        {style: {flex: 1, maxWidth: 60}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 60, height: 200, top: 0, left: 0},
+        {width: 60, height: 200, top: 0, left: 60},
+        {width: 60, height: 200, top: 0, left: 120}
+      ]}
+    );
+  });
+
+  it ('should ignore flex size if fully min bound', function() {
+    testLayout(
+      {style: {width: 300, height: 200, flexDirection: 'row'}, children: [
+        {style: {flex: 1, minWidth: 120}},
+        {style: {flex: 1, minWidth: 120}},
+        {style: {flex: 1, minWidth: 120}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 120, height: 200, top: 0, left: 0},
+        {width: 120, height: 200, top: 0, left: 120},
+        {width: 120, height: 200, top: 0, left: 240}
       ]}
     );
   });

--- a/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
+++ b/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
@@ -4400,6 +4400,116 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.y = 0;
+      node_0.layout.x = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.y = 0;
+        node_1.layout.x = 0;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.y = 0;
+        node_1.layout.x = 60;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.y = 0;
+        node_1.layout.x = 120;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should ignore flex size if fully max bound", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase107()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 120;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 120;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 120;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.y = 0;
+      node_0.layout.x = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.y = 0;
+        node_1.layout.x = 0;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.y = 0;
+        node_1.layout.x = 120;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.y = 0;
+        node_1.layout.x = 240;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should ignore flex size if fully min bound", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase108()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
       node_0.style.width = 300;
       node_0.style.height = 200;
       addChildren(node_0, 1);
@@ -4434,7 +4544,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase107()
+  public void testCase109()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4472,7 +4582,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase108()
+  public void testCase110()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4510,7 +4620,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase109()
+  public void testCase111()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4558,7 +4668,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase110()
+  public void testCase112()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4604,7 +4714,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase111()
+  public void testCase113()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4650,7 +4760,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase112()
+  public void testCase114()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4691,7 +4801,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase113()
+  public void testCase115()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4730,7 +4840,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase114()
+  public void testCase116()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4769,7 +4879,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase115()
+  public void testCase117()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4808,7 +4918,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase116()
+  public void testCase118()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4851,7 +4961,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase117()
+  public void testCase119()
   {
     TestCSSNode root_node = new TestCSSNode();
     {


### PR DESCRIPTION
These commits make the change to attribute access picked up during the review of #65, and adds 2 extra tests for a potential division-by-zero situation. As it happens, the code survives that division-by-zero as is, but it can't hurt to test for the situation anyway.