### PR TITLE
Transpile to update the changes of consts omitted in #69

### DIFF
--- a/src/Layout-test-utils.c
+++ b/src/Layout-test-utils.c
@@ -12,10 +12,10 @@
 
   /** START_GENERATED **/
 #define SMALL_WIDTH 34.671875
-#define SMALL_HEIGHT 16
+#define SMALL_HEIGHT 18
 #define BIG_WIDTH 172.421875
-#define BIG_HEIGHT 32
-#define BIG_MIN_WIDTH 100.453125
+#define BIG_HEIGHT 36
+#define BIG_MIN_WIDTH 100.4375
 #define SMALL_TEXT "small"
 #define LONG_TEXT "loooooooooong with space"
   /** END_GENERATED **/

--- a/src/__tests__/Layout-test.c
+++ b/src/__tests__/Layout-test.c
@@ -2484,7 +2484,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 34.671875;
-      node_0->layout.dimensions[CSS_HEIGHT] = 16;
+      node_0->layout.dimensions[CSS_HEIGHT] = 18;
     }
 
     test("should layout node with just text", root_node, root_layout);
@@ -2505,7 +2505,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 10;
-      node_0->layout.dimensions[CSS_HEIGHT] = 16;
+      node_0->layout.dimensions[CSS_HEIGHT] = 18;
     }
 
     test("should layout node with text and width", root_node, root_layout);
@@ -2525,7 +2525,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 172.421875;
-      node_0->layout.dimensions[CSS_HEIGHT] = 16;
+      node_0->layout.dimensions[CSS_HEIGHT] = 18;
     }
 
     test("should layout node with text, padding and margin", root_node, root_layout);
@@ -2607,7 +2607,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 500;
-      node_0->layout.dimensions[CSS_HEIGHT] = 16;
+      node_0->layout.dimensions[CSS_HEIGHT] = 18;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -2615,7 +2615,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 500;
-        node_1->layout.dimensions[CSS_HEIGHT] = 16;
+        node_1->layout.dimensions[CSS_HEIGHT] = 18;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -2623,7 +2623,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
           node_2->layout.dimensions[CSS_WIDTH] = 500;
-          node_2->layout.dimensions[CSS_HEIGHT] = 16;
+          node_2->layout.dimensions[CSS_HEIGHT] = 18;
         }
       }
     }
@@ -2658,7 +2658,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 130;
-      node_0->layout.dimensions[CSS_HEIGHT] = 32;
+      node_0->layout.dimensions[CSS_HEIGHT] = 36;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -2666,7 +2666,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 130;
-        node_1->layout.dimensions[CSS_HEIGHT] = 32;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -2674,7 +2674,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
           node_2->layout.dimensions[CSS_WIDTH] = 130;
-          node_2->layout.dimensions[CSS_HEIGHT] = 32;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }
@@ -2710,7 +2710,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 200;
-      node_0->layout.dimensions[CSS_HEIGHT] = 32;
+      node_0->layout.dimensions[CSS_HEIGHT] = 36;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -2718,7 +2718,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 200;
-        node_1->layout.dimensions[CSS_HEIGHT] = 32;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -2726,7 +2726,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
           node_2->layout.dimensions[CSS_WIDTH] = 130;
-          node_2->layout.dimensions[CSS_HEIGHT] = 32;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }
@@ -2756,15 +2756,15 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 100;
-      node_0->layout.dimensions[CSS_HEIGHT] = 32;
+      node_0->layout.dimensions[CSS_HEIGHT] = 36;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
         node_1 = node_0->get_child(node_0->context, 0);
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
-        node_1->layout.dimensions[CSS_WIDTH] = 100.453125;
-        node_1->layout.dimensions[CSS_HEIGHT] = 32;
+        node_1->layout.dimensions[CSS_WIDTH] = 100.4375;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
       }
     }
 
@@ -2806,23 +2806,23 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 100;
-      node_0->layout.dimensions[CSS_HEIGHT] = 72;
+      node_0->layout.dimensions[CSS_HEIGHT] = 76;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
         node_1 = node_0->get_child(node_0->context, 0);
         node_1->layout.position[CSS_TOP] = 20;
         node_1->layout.position[CSS_LEFT] = 20;
-        node_1->layout.dimensions[CSS_WIDTH] = 100.453125;
-        node_1->layout.dimensions[CSS_HEIGHT] = 32;
+        node_1->layout.dimensions[CSS_WIDTH] = 100.4375;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
           node_2 = node_1->get_child(node_1->context, 0);
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
-          node_2->layout.dimensions[CSS_WIDTH] = 100.453125;
-          node_2->layout.dimensions[CSS_HEIGHT] = 32;
+          node_2->layout.dimensions[CSS_WIDTH] = 100.4375;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }
@@ -2937,7 +2937,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 200;
-      node_0->layout.dimensions[CSS_HEIGHT] = 56;
+      node_0->layout.dimensions[CSS_HEIGHT] = 58;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -2945,7 +2945,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 200;
-        node_1->layout.dimensions[CSS_HEIGHT] = 56;
+        node_1->layout.dimensions[CSS_HEIGHT] = 58;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -2953,7 +2953,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 20;
           node_2->layout.position[CSS_LEFT] = 20;
           node_2->layout.dimensions[CSS_WIDTH] = 172.421875;
-          node_2->layout.dimensions[CSS_HEIGHT] = 16;
+          node_2->layout.dimensions[CSS_HEIGHT] = 18;
         }
       }
     }
@@ -2990,7 +2990,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 200;
-      node_0->layout.dimensions[CSS_HEIGHT] = 72;
+      node_0->layout.dimensions[CSS_HEIGHT] = 76;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -2998,7 +2998,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 200;
-        node_1->layout.dimensions[CSS_HEIGHT] = 72;
+        node_1->layout.dimensions[CSS_HEIGHT] = 76;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -3006,7 +3006,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 20;
           node_2->layout.position[CSS_LEFT] = 20;
           node_2->layout.dimensions[CSS_WIDTH] = 160;
-          node_2->layout.dimensions[CSS_HEIGHT] = 32;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }

--- a/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
+++ b/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
@@ -2687,7 +2687,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 34.671875f;
-      node_0.layout.height = 16;
+      node_0.layout.height = 18;
     }
 
     test("should layout node with just text", root_node, root_layout);
@@ -2710,7 +2710,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 10;
-      node_0.layout.height = 16;
+      node_0.layout.height = 18;
     }
 
     test("should layout node with text and width", root_node, root_layout);
@@ -2732,7 +2732,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 172.421875f;
-      node_0.layout.height = 16;
+      node_0.layout.height = 18;
     }
 
     test("should layout node with text, padding and margin", root_node, root_layout);
@@ -2818,7 +2818,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 500;
-      node_0.layout.height = 16;
+      node_0.layout.height = 18;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -2826,7 +2826,7 @@ public class LayoutEngineTest {
         node_1.layout.y = 0;
         node_1.layout.x = 0;
         node_1.layout.width = 500;
-        node_1.layout.height = 16;
+        node_1.layout.height = 18;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -2834,7 +2834,7 @@ public class LayoutEngineTest {
           node_2.layout.y = 0;
           node_2.layout.x = 0;
           node_2.layout.width = 500;
-          node_2.layout.height = 16;
+          node_2.layout.height = 18;
         }
       }
     }
@@ -2871,7 +2871,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 130;
-      node_0.layout.height = 32;
+      node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -2879,7 +2879,7 @@ public class LayoutEngineTest {
         node_1.layout.y = 0;
         node_1.layout.x = 0;
         node_1.layout.width = 130;
-        node_1.layout.height = 32;
+        node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -2887,7 +2887,7 @@ public class LayoutEngineTest {
           node_2.layout.y = 0;
           node_2.layout.x = 0;
           node_2.layout.width = 130;
-          node_2.layout.height = 32;
+          node_2.layout.height = 36;
         }
       }
     }
@@ -2925,7 +2925,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 200;
-      node_0.layout.height = 32;
+      node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -2933,7 +2933,7 @@ public class LayoutEngineTest {
         node_1.layout.y = 0;
         node_1.layout.x = 0;
         node_1.layout.width = 200;
-        node_1.layout.height = 32;
+        node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -2941,7 +2941,7 @@ public class LayoutEngineTest {
           node_2.layout.y = 0;
           node_2.layout.x = 0;
           node_2.layout.width = 130;
-          node_2.layout.height = 32;
+          node_2.layout.height = 36;
         }
       }
     }
@@ -2973,15 +2973,15 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 100;
-      node_0.layout.height = 32;
+      node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.layout.y = 0;
         node_1.layout.x = 0;
-        node_1.layout.width = 100.453125f;
-        node_1.layout.height = 32;
+        node_1.layout.width = 100.4375f;
+        node_1.layout.height = 36;
       }
     }
 
@@ -3025,23 +3025,23 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 100;
-      node_0.layout.height = 72;
+      node_0.layout.height = 76;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.layout.y = 20;
         node_1.layout.x = 20;
-        node_1.layout.width = 100.453125f;
-        node_1.layout.height = 32;
+        node_1.layout.width = 100.4375f;
+        node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
           node_2.layout.y = 0;
           node_2.layout.x = 0;
-          node_2.layout.width = 100.453125f;
-          node_2.layout.height = 32;
+          node_2.layout.width = 100.4375f;
+          node_2.layout.height = 36;
         }
       }
     }
@@ -3162,7 +3162,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 200;
-      node_0.layout.height = 56;
+      node_0.layout.height = 58;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -3170,7 +3170,7 @@ public class LayoutEngineTest {
         node_1.layout.y = 0;
         node_1.layout.x = 0;
         node_1.layout.width = 200;
-        node_1.layout.height = 56;
+        node_1.layout.height = 58;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -3178,7 +3178,7 @@ public class LayoutEngineTest {
           node_2.layout.y = 20;
           node_2.layout.x = 20;
           node_2.layout.width = 172.421875f;
-          node_2.layout.height = 16;
+          node_2.layout.height = 18;
         }
       }
     }
@@ -3217,7 +3217,7 @@ public class LayoutEngineTest {
       node_0.layout.y = 0;
       node_0.layout.x = 0;
       node_0.layout.width = 200;
-      node_0.layout.height = 72;
+      node_0.layout.height = 76;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -3225,7 +3225,7 @@ public class LayoutEngineTest {
         node_1.layout.y = 0;
         node_1.layout.x = 0;
         node_1.layout.width = 200;
-        node_1.layout.height = 72;
+        node_1.layout.height = 76;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -3233,7 +3233,7 @@ public class LayoutEngineTest {
           node_2.layout.y = 20;
           node_2.layout.x = 20;
           node_2.layout.width = 160;
-          node_2.layout.height = 32;
+          node_2.layout.height = 36;
         }
       }
     }

--- a/src/java/tests/com/facebook/csslayout/TestConstants.java
+++ b/src/java/tests/com/facebook/csslayout/TestConstants.java
@@ -15,10 +15,10 @@ public class TestConstants {
 
   /** START_GENERATED **/
   public static final float SMALL_WIDTH = 34.671875f;
-  public static final float SMALL_HEIGHT = 16f;
+  public static final float SMALL_HEIGHT = 18f;
   public static final float BIG_WIDTH = 172.421875f;
-  public static final float BIG_HEIGHT = 32f;
-  public static final float BIG_MIN_WIDTH = 100.453125f;
+  public static final float BIG_HEIGHT = 36f;
+  public static final float BIG_MIN_WIDTH = 100.4375f;
   public static final String SMALL_TEXT = "small";
   public static final String LONG_TEXT = "loooooooooong with space";
   /** END_GENERATED **/


### PR DESCRIPTION
#69 includes [the changes of `preDefinedTextSizes`][1] but the corresponding transpiled results are omitted. So currently they have different text size constants that the JavaScript test case and C and Java's one.

[1]: https://github.com/facebook/css-layout/blob/1cbb5eef26478bc79ae4f823cd15e537f90e26c0/src/Layout-test-utils.js#L362-L368