### PR TITLE
[Layout.c/h]: Minor modifications so that the Microsoft compiler can compile the file as C++ directly ;

### DIFF
--- a/src/Layout.c
+++ b/src/Layout.c
@@ -11,9 +11,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 
 #include "Layout.h"
+
+#ifdef _MSC_VER
+#include <float.h>
+#define isnan _isnan
+__forceinline const float fmaxf(const float a, const float b) {
+  return (a > b) ? a : b;
+}
+#endif
 
 bool isUndefined(float value) {
   return isnan(value);
@@ -55,7 +62,7 @@ void init_css_node(css_node_t *node) {
 }
 
 css_node_t *new_css_node() {
-  css_node_t *node = calloc(1, sizeof(*node));
+  css_node_t *node = (css_node_t *)calloc(1, sizeof(*node));
   init_css_node(node);
   return node;
 }

--- a/src/Layout.h
+++ b/src/Layout.h
@@ -11,7 +11,16 @@
 #define __LAYOUT_H
 
 #include <math.h>
+#ifndef __cplusplus
 #include <stdbool.h>
+#endif
+
+// Not defined in MSVC++
+#ifndef NAN
+static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
+#define NAN (*(const float *)__nan)
+#endif
+
 #define CSS_UNDEFINED NAN
 
 typedef enum {


### PR DESCRIPTION
Visual C++ doesn't support C99, the simplest way is to compile the C as C++ (by changing the extension or with the /Tp extension on the command line).

These changes account for the fact that its C++ instead of C (one explicit cast), and for the lib C differences.