### PR TITLE
If the measure function is defined: only return from execution of lay…

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -315,7 +315,9 @@ var computeLayout = (function() {
             getPaddingAndBorderAxis(node, CSS_FLEX_DIRECTION_COLUMN);
         }
       }
-      return;
+      if (node->children_count === 0) {
+        return;
+      }
     }
 
     var/*int*/ i;


### PR DESCRIPTION
…outNode, when the node has no children.

I'am currently working on a new implementation of the TextView element in react-native.
My implementation uses the node->measure function to calculate the height of the element, but a TextView may also have subviews. If thats the case it's necessary to execute the rest of the layoutNode function and not stopping it after line 318.
This change does not affect the behaviour of the other module ( RCText ), that uses the measure function, because this element will always have a children_count of zero.