### PR TITLE
Support RTL direction and ROW_REVERSE & COLUMN_REVERSE flex direction

### DIFF
--- a/src/JavaTranspiler.js
+++ b/src/JavaTranspiler.js
@@ -11,6 +11,8 @@ function __transpileToJavaCommon(code) {
   return code
     .replace(/CSS_UNDEFINED/g, 'CSSConstants.UNDEFINED')
     .replace(/css_flex_direction_t/g, 'CSSFlexDirection')
+    .replace(/css_direction_t/g, 'CSSDirection')
+    .replace(/CSS_DIRECTION_/g, 'CSSDirection.')
     .replace(/CSS_FLEX_DIRECTION_/g, 'CSSFlexDirection.')
     .replace(/css_align_t/g, 'CSSAlign')
     .replace(/CSS_ALIGN_/g, 'CSSAlign.')
@@ -33,7 +35,11 @@ function __transpileToJavaCommon(code) {
     .replace(
         /(\w+)\.layout\[((?:getLeading|getPos)\([^\)]+\))\]\s+=\s+([^;]+);/gm,
         'setLayoutPosition($1, $2, $3);')
+    .replace(
+        /(\w+)\.layout\[((?:getTrailing|getPos)\([^\)]+\))\]\s+=\s+([^;]+);/gm,
+        'setLayoutPosition($1, $2, $3);')
     .replace(/(\w+)\.layout\[((?:getLeading|getPos)\([^\]]+\))\]/g, 'getLayoutPosition($1, $2)')
+    .replace(/(\w+)\.layout\[((?:getTrailing|getPos)\([^\]]+\))\]/g, 'getLayoutPosition($1, $2)')
     .replace(
         /(\w+)\.layout\[(getDim\([^\)]+\))\]\s+=\s+([^;]+);/gm,
         'setLayoutDimension($1, $2, $3);')
@@ -63,7 +69,7 @@ function __transpileSingleTestToJava(code) {
     .replace( // layout.position[CSS_TOP] => layout.y
         /layout\.position\[CSS_(TOP|LEFT)\]/g,
         function (str, match1) {
-            return 'layout.' + (match1 === 'TOP' ? 'y' : 'x');
+            return 'layout.' + (match1 === 'TOP' ? 'top' : 'left');
         })
     .replace( // style.position[CSS_TOP] => style.positionTop
         /style\.(position)\[CSS_(TOP|BOTTOM|LEFT|RIGHT)\]/g,

--- a/src/Layout-test-utils.c
+++ b/src/Layout-test-utils.c
@@ -88,7 +88,7 @@ css_dim_t measure(void *context, float width) {
 }
 
 void test(const char *name, css_node_t *style, css_node_t *expected_layout) {
-  layoutNode(style, CSS_UNDEFINED);
+  layoutNode(style, CSS_UNDEFINED, -1);
 
   if (!are_layout_equal(style, expected_layout)) {
     printf("%sF%s", "\x1B[31m", "\x1B[0m");

--- a/src/Layout-test-utils.js
+++ b/src/Layout-test-utils.js
@@ -184,6 +184,7 @@ var layoutTestUtils = (function() {
       transferSpacing(div, node, 'padding', '');
       transferSpacing(div, node, 'border', 'Width');
       transfer(div, node, 'flexDirection');
+      transfer(div, node, 'direction');
       transfer(div, node, 'flex');
       transfer(div, node, 'flexWrap');
       transfer(div, node, 'justifyContent');

--- a/src/Layout.h
+++ b/src/Layout.h
@@ -24,8 +24,16 @@ static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
 #define CSS_UNDEFINED NAN
 
 typedef enum {
+  CSS_DIRECTION_INHERIT = 0,
+  CSS_DIRECTION_LTR,
+  CSS_DIRECTION_RTL
+} css_direction_t;
+
+typedef enum {
   CSS_FLEX_DIRECTION_COLUMN = 0,
-  CSS_FLEX_DIRECTION_ROW
+  CSS_FLEX_DIRECTION_COLUMN_REVERSE,
+  CSS_FLEX_DIRECTION_ROW,
+  CSS_FLEX_DIRECTION_ROW_REVERSE
 } css_flex_direction_t;
 
 typedef enum {
@@ -72,7 +80,7 @@ typedef enum {
 } css_dimension_t;
 
 typedef struct {
-  float position[2];
+  float position[4];
   float dimensions[2];
 
   // Instead of recomputing the entire layout every single time, we
@@ -82,6 +90,7 @@ typedef struct {
   float last_parent_max_width;
   float last_dimensions[2];
   float last_position[2];
+  css_direction_t last_direction;
 } css_layout_t;
 
 typedef struct {
@@ -89,6 +98,7 @@ typedef struct {
 } css_dim_t;
 
 typedef struct {
+  css_direction_t direction;
   css_flex_direction_t flex_direction;
   css_justify_t justify_content;
   css_align_t align_items;
@@ -142,7 +152,7 @@ typedef enum {
 void print_css_node(css_node_t *node, css_print_options_t options);
 
 // Function that computes the layout!
-void layoutNode(css_node_t *node, float maxWidth);
+void layoutNode(css_node_t *node, float maxWidth, css_direction_t parentDirection);
 bool isUndefined(float value);
 
 #endif

--- a/src/__tests__/Layout-test.c
+++ b/src/__tests__/Layout-test.c
@@ -90,6 +90,59 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 500;
+        node_1->style.dimensions[CSS_HEIGHT] = 500;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 250;
+        node_1->style.dimensions[CSS_HEIGHT] = 250;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.dimensions[CSS_WIDTH] = 125;
+        node_1->style.dimensions[CSS_HEIGHT] = 125;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 500;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 500;
+        node_1->layout.dimensions[CSS_HEIGHT] = 500;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 250;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 250;
+        node_1->layout.dimensions[CSS_HEIGHT] = 250;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 125;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 125;
+        node_1->layout.dimensions[CSS_HEIGHT] = 125;
+      }
+    }
+
+    test("should layout node with children in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
       init_css_node_children(node_0, 2);
@@ -152,6 +205,76 @@ int main()
     }
 
     test("should layout node with nested children", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 500;
+        node_1->style.dimensions[CSS_HEIGHT] = 500;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+        node_1->style.dimensions[CSS_WIDTH] = 500;
+        node_1->style.dimensions[CSS_HEIGHT] = 500;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.dimensions[CSS_WIDTH] = 250;
+          node_2->style.dimensions[CSS_HEIGHT] = 250;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->style.dimensions[CSS_WIDTH] = 250;
+          node_2->style.dimensions[CSS_HEIGHT] = 250;
+        }
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 500;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 500;
+        node_1->layout.dimensions[CSS_HEIGHT] = 500;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 500;
+        node_1->layout.dimensions[CSS_HEIGHT] = 500;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 250;
+          node_2->layout.position[CSS_LEFT] = 0;
+          node_2->layout.dimensions[CSS_WIDTH] = 250;
+          node_2->layout.dimensions[CSS_HEIGHT] = 250;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 0;
+          node_2->layout.dimensions[CSS_WIDTH] = 250;
+          node_2->layout.dimensions[CSS_HEIGHT] = 250;
+        }
+      }
+    }
+
+    test("should layout node with nested children in reverse", root_node, root_layout);
   }
 
   {
@@ -250,6 +373,121 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      node_0->style.margin[CSS_LEFT] = 10;
+      node_0->style.margin[CSS_TOP] = 10;
+      node_0->style.margin[CSS_RIGHT] = 10;
+      node_0->style.margin[CSS_BOTTOM] = 10;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1->style.margin[CSS_LEFT] = 50;
+        node_1->style.margin[CSS_TOP] = 50;
+        node_1->style.margin[CSS_RIGHT] = 50;
+        node_1->style.margin[CSS_BOTTOM] = 50;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1->style.margin[CSS_LEFT] = 25;
+        node_1->style.margin[CSS_TOP] = 25;
+        node_1->style.margin[CSS_RIGHT] = 25;
+        node_1->style.margin[CSS_BOTTOM] = 25;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1->style.margin[CSS_LEFT] = 10;
+        node_1->style.margin[CSS_TOP] = 10;
+        node_1->style.margin[CSS_RIGHT] = 10;
+        node_1->style.margin[CSS_BOTTOM] = 10;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 10;
+      node_0->layout.position[CSS_LEFT] = 10;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 850;
+        node_1->layout.position[CSS_LEFT] = 50;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 675;
+        node_1->layout.position[CSS_LEFT] = 25;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 540;
+        node_1->layout.position[CSS_LEFT] = 10;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with several children in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 300;
+        node_1->style.dimensions[CSS_HEIGHT] = 150;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 100;
+        node_1->layout.dimensions[CSS_WIDTH] = 300;
+        node_1->layout.dimensions[CSS_HEIGHT] = 150;
+      }
+    }
+
+    test("should layout rtl with reverse correctly", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -289,6 +527,52 @@ int main()
     }
 
     test("should layout node with row flex direction", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 300;
+        node_1->style.dimensions[CSS_HEIGHT] = 150;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 900;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 600;
+        node_1->layout.dimensions[CSS_WIDTH] = 300;
+        node_1->layout.dimensions[CSS_HEIGHT] = 150;
+      }
+    }
+
+    test("should layout node with row flex direction in rtl", root_node, root_layout);
   }
 
   {
@@ -338,6 +622,50 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 300;
+        node_1->style.dimensions[CSS_HEIGHT] = 150;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 350;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 150;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 300;
+        node_1->layout.dimensions[CSS_HEIGHT] = 150;
+      }
+    }
+
+    test("should layout node based on children main dimensions in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
       init_css_node_children(node_0, 2);
@@ -376,6 +704,51 @@ int main()
     }
 
     test("should layout node with just flex", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 800;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 800;
+      }
+    }
+
+    test("should layout node with just flex in reverse", root_node, root_layout);
   }
 
   {
@@ -450,6 +823,78 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+        node_1->style.flex = 1;
+        node_1->style.dimensions[CSS_WIDTH] = 1000;
+        init_css_node_children(node_1, 1);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+          node_2->style.flex = 1;
+          node_2->style.dimensions[CSS_WIDTH] = 1000;
+          init_css_node_children(node_2, 1);
+          {
+            css_node_t *node_3;
+            node_3 = node_2->get_child(node_2->context, 0);
+            node_3->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+            node_3->style.flex = 1;
+            node_3->style.dimensions[CSS_WIDTH] = 1000;
+          }
+        }
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 1000;
+        node_1->layout.dimensions[CSS_HEIGHT] = 1000;
+        init_css_node_children(node_1, 1);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 0;
+          node_2->layout.dimensions[CSS_WIDTH] = 1000;
+          node_2->layout.dimensions[CSS_HEIGHT] = 1000;
+          init_css_node_children(node_2, 1);
+          {
+            css_node_t *node_3;
+            node_3 = node_2->get_child(node_2->context, 0);
+            node_3->layout.position[CSS_TOP] = 0;
+            node_3->layout.position[CSS_LEFT] = 0;
+            node_3->layout.dimensions[CSS_WIDTH] = 1000;
+            node_3->layout.dimensions[CSS_HEIGHT] = 1000;
+          }
+        }
+      }
+    }
+
+    test("should layout node with flex recursively in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
       node_0->style.margin[CSS_LEFT] = 5;
@@ -494,6 +939,57 @@ int main()
     }
 
     test("should layout node with targeted margin", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      node_0->style.margin[CSS_LEFT] = 5;
+      node_0->style.margin[CSS_TOP] = 10;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1->style.margin[CSS_LEFT] = 15;
+        node_1->style.margin[CSS_TOP] = 50;
+        node_1->style.margin[CSS_BOTTOM] = 20;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1->style.margin[CSS_LEFT] = 30;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 10;
+      node_0->layout.position[CSS_LEFT] = 5;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 880;
+        node_1->layout.position[CSS_LEFT] = 15;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 730;
+        node_1->layout.position[CSS_LEFT] = 30;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with targeted margin in reverse", root_node, root_layout);
   }
 
   {
@@ -545,6 +1041,52 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_FLEX_START;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 800;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: flex-start in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.justify_content = CSS_JUSTIFY_FLEX_END;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -584,6 +1126,52 @@ int main()
     }
 
     test("should layout node with justifyContent: flex-end", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_FLEX_END;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 100;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: flex-end in reverse", root_node, root_layout);
   }
 
   {
@@ -635,6 +1223,52 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_SPACE_BETWEEN;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: space-between in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.justify_content = CSS_JUSTIFY_SPACE_AROUND;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -680,6 +1314,52 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_SPACE_AROUND;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 700;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 200;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: space-around in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.justify_content = CSS_JUSTIFY_CENTER;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -719,6 +1399,52 @@ int main()
     }
 
     test("should layout node with justifyContent: center", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_CENTER;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 500;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 400;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: center in reverse", root_node, root_layout);
   }
 
   {
@@ -807,6 +1533,52 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_items = CSS_ALIGN_FLEX_START;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 200;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 800;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with alignItems: flex-start in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.align_items = CSS_ALIGN_CENTER;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -852,6 +1624,52 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_items = CSS_ALIGN_CENTER;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 200;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 400;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 800;
+        node_1->layout.position[CSS_LEFT] = 450;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with alignItems: center in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.align_items = CSS_ALIGN_FLEX_END;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -891,6 +1709,52 @@ int main()
     }
 
     test("should layout node with alignItems: flex-end", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_items = CSS_ALIGN_FLEX_END;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 200;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 800;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 800;
+        node_1->layout.position[CSS_LEFT] = 900;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with alignItems: flex-end in reverse", root_node, root_layout);
   }
 
   {
@@ -943,6 +1807,53 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_items = CSS_ALIGN_FLEX_END;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 200;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.align_self = CSS_ALIGN_CENTER;
+        node_1->style.dimensions[CSS_WIDTH] = 100;
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 800;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 800;
+        node_1->layout.position[CSS_LEFT] = 450;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with alignSelf overrides alignItems in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.align_items = CSS_ALIGN_STRETCH;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
@@ -979,6 +1890,43 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_items = CSS_ALIGN_STRETCH;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      node_0->style.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 1000;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 900;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 1000;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+      }
+    }
+
+    test("should layout node with alignItem: stretch in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -1005,6 +1953,39 @@ int main()
     }
 
     test("should layout empty node", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 0;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout empty node in reverse", root_node, root_layout);
   }
 
   {
@@ -1047,6 +2028,43 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.margin[CSS_LEFT] = 5;
+        node_1->style.margin[CSS_TOP] = 5;
+        node_1->style.margin[CSS_RIGHT] = 5;
+        node_1->style.margin[CSS_BOTTOM] = 5;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 10;
+      node_0->layout.dimensions[CSS_HEIGHT] = 10;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 5;
+        node_1->layout.position[CSS_LEFT] = 5;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout child with margin in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.dimensions[CSS_HEIGHT] = 100;
       init_css_node_children(node_0, 2);
       {
@@ -1082,6 +2100,48 @@ int main()
     }
 
     test("should not shrink children if not enough space", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 0;
+      node_0->layout.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 100;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = -200;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should not shrink children if not enough space in reverse", root_node, root_layout);
   }
 
   {
@@ -1136,6 +2196,42 @@ int main()
     }
 
     test("should layout flex-end taking into account margin", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_FLEX_END;
+      node_0->style.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.margin[CSS_TOP] = 10;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 0;
+      node_0->layout.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 10;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout flex-end taking into account margin in reverse", root_node, root_layout);
   }
 
   {
@@ -1204,6 +2300,65 @@ int main()
       {
         css_node_t *node_1;
         node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+        node_1->style.align_items = CSS_ALIGN_FLEX_END;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.margin[CSS_LEFT] = 10;
+          node_2->style.margin[CSS_TOP] = 10;
+          node_2->style.margin[CSS_RIGHT] = 10;
+          node_2->style.margin[CSS_BOTTOM] = 10;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->style.dimensions[CSS_HEIGHT] = 100;
+        }
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 20;
+      node_0->layout.dimensions[CSS_HEIGHT] = 120;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 20;
+        node_1->layout.dimensions[CSS_HEIGHT] = 120;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 110;
+          node_2->layout.position[CSS_LEFT] = 10;
+          node_2->layout.dimensions[CSS_WIDTH] = 0;
+          node_2->layout.dimensions[CSS_HEIGHT] = 0;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 20;
+          node_2->layout.dimensions[CSS_WIDTH] = 0;
+          node_2->layout.dimensions[CSS_HEIGHT] = 100;
+        }
+      }
+    }
+
+    test("should layout alignItems with margin in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
         node_1->style.flex = 1;
       }
     }
@@ -1261,6 +2416,41 @@ int main()
     }
 
     test("should layout alignItems stretch and margin", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_items = CSS_ALIGN_STRETCH;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.margin[CSS_LEFT] = 10;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 10;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 10;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout alignItems stretch and margin in reverse", root_node, root_layout);
   }
 
   {
@@ -2030,6 +3220,48 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_SPACE_AROUND;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.position_type = CSS_POSITION_ABSOLUTE;
+        node_1 = node_0->get_child(node_0->context, 1);
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 0;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 100;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 100;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout node with space-around and child position absolute in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.dimensions[CSS_WIDTH] = 700;
       init_css_node_children(node_0, 1);
@@ -2060,6 +3292,43 @@ int main()
     }
 
     test("should layout node with flex and main margin", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 700;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1->style.margin[CSS_RIGHT] = 5;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 700;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 695;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout node with flex and main margin in rtl", root_node, root_layout);
   }
 
   {
@@ -2109,6 +3378,50 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 700;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.padding[CSS_LEFT] = 5;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 700;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 352.5;
+        node_1->layout.dimensions[CSS_WIDTH] = 347.5;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 352.5;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout node with multiple flex and padding in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.dimensions[CSS_WIDTH] = 700;
       init_css_node_children(node_0, 2);
@@ -2146,6 +3459,50 @@ int main()
     }
 
     test("should layout node with multiple flex and margin", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 700;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.margin[CSS_RIGHT] = 5;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 700;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 352.5;
+        node_1->layout.dimensions[CSS_WIDTH] = 347.5;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 347.5;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout node with multiple flex and margin in rtl", root_node, root_layout);
   }
 
   {
@@ -2223,6 +3580,43 @@ int main()
     }
 
     test("should layout node with flex and position absolute", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 600;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.position_type = CSS_POSITION_ABSOLUTE;
+        node_1->style.flex = 1;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 600;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 600;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout node with flex and position absolute in rtl", root_node, root_layout);
   }
 
   {
@@ -2474,6 +3868,42 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.border[CSS_LEFT] = 1;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.margin[CSS_LEFT] = -8;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 1;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should handle negative margin and min padding correctly in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->measure = measure;
       node_0->context = "small";
     }
@@ -2629,6 +4059,58 @@ int main()
     }
 
     test("should layout node with text and flex", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.direction = CSS_DIRECTION_RTL;
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+        node_1->style.dimensions[CSS_WIDTH] = 500;
+        init_css_node_children(node_1, 1);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.flex = 1;
+          node_2->measure = measure;
+          node_2->context = "loooooooooong with space";
+        }
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 500;
+      node_0->layout.dimensions[CSS_HEIGHT] = 18;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 500;
+        node_1->layout.dimensions[CSS_HEIGHT] = 18;
+        init_css_node_children(node_1, 1);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 0;
+          node_2->layout.dimensions[CSS_WIDTH] = 500;
+          node_2->layout.dimensions[CSS_HEIGHT] = 18;
+        }
+      }
+    }
+
+    test("should layout node with text and flex in rtl", root_node, root_layout);
   }
 
   {
@@ -2875,6 +4357,48 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.justify_content = CSS_JUSTIFY_SPACE_BETWEEN;
+      node_0->style.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_HEIGHT] = 900;
+        node_1 = node_0->get_child(node_0->context, 1);
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 0;
+      node_0->layout.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = -800;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 900;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = -800;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout space-between when remaining space is negative in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.justify_content = CSS_JUSTIFY_FLEX_END;
       node_0->style.dimensions[CSS_WIDTH] = 200;
@@ -2905,6 +4429,43 @@ int main()
     }
 
     test("should layout flex-end when remaining space is negative", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.justify_content = CSS_JUSTIFY_FLEX_END;
+      node_0->style.dimensions[CSS_WIDTH] = 200;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 900;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 200;
+      node_0->layout.dimensions[CSS_HEIGHT] = 0;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 900;
+        node_1->layout.dimensions[CSS_HEIGHT] = 0;
+      }
+    }
+
+    test("should layout flex-end when remaining space is negative in rtl", root_node, root_layout);
   }
 
   {
@@ -2959,6 +4520,61 @@ int main()
     }
 
     test("should layout text with flexDirection row", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+        node_1->style.dimensions[CSS_WIDTH] = 200;
+        init_css_node_children(node_1, 1);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.margin[CSS_LEFT] = 20;
+          node_2->style.margin[CSS_TOP] = 20;
+          node_2->style.margin[CSS_RIGHT] = 20;
+          node_2->style.margin[CSS_BOTTOM] = 20;
+          node_2->measure = measure;
+          node_2->context = "loooooooooong with space";
+        }
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 200;
+      node_0->layout.dimensions[CSS_HEIGHT] = 58;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 58;
+        init_css_node_children(node_1, 1);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 20;
+          node_2->layout.position[CSS_LEFT] = 7.578125;
+          node_2->layout.dimensions[CSS_WIDTH] = 172.421875;
+          node_2->layout.dimensions[CSS_HEIGHT] = 18;
+        }
+      }
+    }
+
+    test("should layout text with flexDirection row in rtl", root_node, root_layout);
   }
 
   {
@@ -3102,6 +4718,53 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
+      node_0->style.align_self = CSS_ALIGN_FLEX_START;
+      node_0->style.dimensions[CSS_WIDTH] = 100;
+      node_0->style.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.align_self = CSS_ALIGN_FLEX_START;
+        node_1->style.flex = 2.5;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.align_self = CSS_ALIGN_FLEX_START;
+        node_1->style.flex = 7.5;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 100;
+      node_0->layout.dimensions[CSS_HEIGHT] = 100;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 75;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 25;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 0;
+        node_1->layout.dimensions[CSS_HEIGHT] = 75;
+      }
+    }
+
+    test("should layout with arbitrary flex in reverse", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_COLUMN_REVERSE;
       node_0->style.align_self = CSS_ALIGN_FLEX_START;
       node_0->style.dimensions[CSS_WIDTH] = 100;
       node_0->style.dimensions[CSS_HEIGHT] = 100;
@@ -3128,19 +4791,19 @@ int main()
       {
         css_node_t *node_1;
         node_1 = node_0->get_child(node_0->context, 0);
-        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_TOP] = 100;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 0;
         node_1->layout.dimensions[CSS_HEIGHT] = 0;
         node_1 = node_0->get_child(node_0->context, 1);
-        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_TOP] = 100;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 0;
         node_1->layout.dimensions[CSS_HEIGHT] = 0;
       }
     }
 
-    test("should layout with negative flex", root_node, root_layout);
+    test("should layout with negative flex in reverse", root_node, root_layout);
   }
 
   {
@@ -3731,6 +5394,60 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.flex_wrap = CSS_WRAP;
+      node_0->style.dimensions[CSS_WIDTH] = 100;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_WIDTH] = 40;
+        node_1->style.dimensions[CSS_HEIGHT] = 10;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.dimensions[CSS_WIDTH] = 40;
+        node_1->style.dimensions[CSS_HEIGHT] = 10;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.dimensions[CSS_WIDTH] = 40;
+        node_1->style.dimensions[CSS_HEIGHT] = 10;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 100;
+      node_0->layout.dimensions[CSS_HEIGHT] = 20;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 60;
+        node_1->layout.dimensions[CSS_WIDTH] = 40;
+        node_1->layout.dimensions[CSS_HEIGHT] = 10;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 20;
+        node_1->layout.dimensions[CSS_WIDTH] = 40;
+        node_1->layout.dimensions[CSS_HEIGHT] = 10;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 10;
+        node_1->layout.position[CSS_LEFT] = 60;
+        node_1->layout.dimensions[CSS_WIDTH] = 40;
+        node_1->layout.dimensions[CSS_HEIGHT] = 10;
+      }
+    }
+
+    test("should layout flex-wrap in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_wrap = CSS_WRAP;
       node_0->style.dimensions[CSS_HEIGHT] = 100;
       init_css_node_children(node_0, 2);
@@ -4008,6 +5725,58 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 250;
+        node_1->layout.dimensions[CSS_WIDTH] = 50;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 50;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 50;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should override flex direction size with min bounds in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.dimensions[CSS_WIDTH] = 300;
       node_0->style.dimensions[CSS_HEIGHT] = 200;
@@ -4060,6 +5829,59 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 110;
+        node_1->style.minDimensions[CSS_WIDTH] = 90;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 200;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 100;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should not override flex direction size within bounds in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.dimensions[CSS_WIDTH] = 300;
       node_0->style.dimensions[CSS_HEIGHT] = 200;
@@ -4105,6 +5927,58 @@ int main()
     }
 
     test("should override flex direction size with max bounds", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 180;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 120;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should override flex direction size with max bounds in rtl", root_node, root_layout);
   }
 
   {
@@ -4164,6 +6038,60 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+        node_1->style.maxDimensions[CSS_WIDTH] = 60;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 240;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 180;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 120;
+        node_1->layout.dimensions[CSS_WIDTH] = 60;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should ignore flex size if fully max bound in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
       node_0->style.dimensions[CSS_WIDTH] = 300;
       node_0->style.dimensions[CSS_HEIGHT] = 200;
@@ -4211,6 +6139,60 @@ int main()
     }
 
     test("should ignore flex size if fully min bound", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 300;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 120;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 120;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->style.flex = 1;
+        node_1->style.minDimensions[CSS_WIDTH] = 120;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 300;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 3);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 180;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 60;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+        node_1 = node_0->get_child(node_0->context, 2);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = -60;
+        node_1->layout.dimensions[CSS_WIDTH] = 120;
+        node_1->layout.dimensions[CSS_HEIGHT] = 200;
+      }
+    }
+
+    test("should ignore flex size if fully min bound in rtl", root_node, root_layout);
   }
 
   {
@@ -4610,6 +6592,44 @@ int main()
     css_node_t *root_node = new_test_css_node();
     {
       css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+      node_0->style.dimensions[CSS_WIDTH] = 1000;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.dimensions[CSS_HEIGHT] = 100;
+        node_1->style.minDimensions[CSS_WIDTH] = 100;
+        node_1->style.minDimensions[CSS_HEIGHT] = 110;
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 1000;
+      node_0->layout.dimensions[CSS_HEIGHT] = 110;
+      init_css_node_children(node_0, 1);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 900;
+        node_1->layout.dimensions[CSS_WIDTH] = 100;
+        node_1->layout.dimensions[CSS_HEIGHT] = 110;
+      }
+    }
+
+    test("should keep cross axis size within min bounds in rtl", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
       node_0->style.dimensions[CSS_WIDTH] = 1000;
       node_0->style.dimensions[CSS_HEIGHT] = 1000;
       init_css_node_children(node_0, 1);
@@ -4872,6 +6892,98 @@ int main()
     }
 
     test("should layout absolutely positioned node with padded flex 1 parent", root_node, root_layout);
+  }
+
+  {
+    css_node_t *root_node = new_test_css_node();
+    {
+      css_node_t *node_0 = root_node;
+      node_0->style.direction = CSS_DIRECTION_RTL;
+      node_0->style.dimensions[CSS_WIDTH] = 200;
+      node_0->style.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.dimensions[CSS_WIDTH] = 50;
+          node_2->style.dimensions[CSS_HEIGHT] = 50;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->style.dimensions[CSS_WIDTH] = 50;
+          node_2->style.dimensions[CSS_HEIGHT] = 50;
+        }
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->style.direction = CSS_DIRECTION_LTR;
+        node_1->style.flex_direction = CSS_FLEX_DIRECTION_ROW;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->style.dimensions[CSS_WIDTH] = 50;
+          node_2->style.dimensions[CSS_HEIGHT] = 50;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->style.dimensions[CSS_WIDTH] = 50;
+          node_2->style.dimensions[CSS_HEIGHT] = 50;
+        }
+      }
+    }
+
+    css_node_t *root_layout = new_test_css_node();
+    {
+      css_node_t *node_0 = root_layout;
+      node_0->layout.position[CSS_TOP] = 0;
+      node_0->layout.position[CSS_LEFT] = 0;
+      node_0->layout.dimensions[CSS_WIDTH] = 200;
+      node_0->layout.dimensions[CSS_HEIGHT] = 200;
+      init_css_node_children(node_0, 2);
+      {
+        css_node_t *node_1;
+        node_1 = node_0->get_child(node_0->context, 0);
+        node_1->layout.position[CSS_TOP] = 0;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 50;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 150;
+          node_2->layout.dimensions[CSS_WIDTH] = 50;
+          node_2->layout.dimensions[CSS_HEIGHT] = 50;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 100;
+          node_2->layout.dimensions[CSS_WIDTH] = 50;
+          node_2->layout.dimensions[CSS_HEIGHT] = 50;
+        }
+        node_1 = node_0->get_child(node_0->context, 1);
+        node_1->layout.position[CSS_TOP] = 50;
+        node_1->layout.position[CSS_LEFT] = 0;
+        node_1->layout.dimensions[CSS_WIDTH] = 200;
+        node_1->layout.dimensions[CSS_HEIGHT] = 50;
+        init_css_node_children(node_1, 2);
+        {
+          css_node_t *node_2;
+          node_2 = node_1->get_child(node_1->context, 0);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 0;
+          node_2->layout.dimensions[CSS_WIDTH] = 50;
+          node_2->layout.dimensions[CSS_HEIGHT] = 50;
+          node_2 = node_1->get_child(node_1->context, 1);
+          node_2->layout.position[CSS_TOP] = 0;
+          node_2->layout.position[CSS_LEFT] = 50;
+          node_2->layout.dimensions[CSS_WIDTH] = 50;
+          node_2->layout.dimensions[CSS_HEIGHT] = 50;
+        }
+      }
+    }
+
+    test("should layout nested nodes with mixed directions", root_node, root_layout);
   }
   /** END_GENERATED **/
   return tests_finished();

--- a/src/__tests__/Layout-test.js
+++ b/src/__tests__/Layout-test.js
@@ -19,14 +19,14 @@ describe('Javascript Only', function() {
   it('should fill root node with layout, style, and children', function() {
     testFillNodes(
       {},
-      {layout: {width: undefined, height: undefined, top: 0, left: 0}, style: {}, children: []}
+      {layout: {width: undefined, height: undefined, top: 0, left: 0, right: 0, bottom: 0}, style: {}, children: []}
     );
   });
   it('should fill root and child node with layout, style, and children', function() {
     testFillNodes(
       {children: [{}]},
-      {layout: {width: undefined, height: undefined, top: 0, left: 0}, style: {}, children: [
-        {layout: {width: undefined, height: undefined, top: 0, left: 0}, style: {}, children: []}
+      {layout: {width: undefined, height: undefined, top: 0, left: 0, right: 0, bottom: 0}, style: {}, children: [
+        {layout: {width: undefined, height: undefined, top: 0, left: 0, right: 0, bottom: 0}, style: {}, children: []}
       ]}
     );
   });
@@ -46,8 +46,8 @@ describe('Javascript Only', function() {
       ]}
     );
   });
-
 });
+
 
 describe('Layout', function() {
   it('should layout a single node with width and height', function() {
@@ -73,6 +73,21 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with children in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse'}, children: [
+        {style: {width: 500, height: 500}},
+        {style: {width: 250, height: 250}},
+        {style: {width: 125, height: 125}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 500, height: 500, top: 500, left: 0},
+        {width: 250, height: 250, top: 250, left: 0},
+        {width: 125, height: 125, top: 125, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with nested children', function() {
     testLayout(
       {style: {width: 1000, height: 1000}, children: [
@@ -87,6 +102,25 @@ describe('Layout', function() {
         {width: 500, height: 500, top: 500, left: 0, children: [
           {width: 250, height: 250, top: 0, left: 0},
           {width: 250, height: 250, top: 250, left: 0}
+        ]}
+      ]}
+    );
+  });
+
+  it('should layout node with nested children in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse'}, children: [
+        {style: {width: 500, height: 500}},
+        {style: {width: 500, height: 500, flexDirection: 'column-reverse'}, children: [
+          {style: {width: 250, height: 250}},
+          {style: {width: 250, height: 250}}
+        ]}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 500, height: 500, top: 500, left: 0},
+        {width: 500, height: 500, top: 0, left: 0, children: [
+          {width: 250, height: 250, top: 250, left: 0},
+          {width: 250, height: 250, top: 0, left: 0}
         ]}
       ]}
     );
@@ -114,6 +148,34 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with several children in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', margin: 10}, children: [
+        {style: {width: 100, height: 100, margin: 50}},
+        {style: {width: 100, height: 100, margin: 25}},
+        {style: {width: 100, height: 100, margin: 10}}
+      ]},
+      {width: 1000, height: 1000, top: 10, left: 10, children: [
+        {width: 100, height: 100, top: 850, left: 50},
+        {width: 100, height: 100, top: 675, left: 25},
+        {width: 100, height: 100, top: 540, left: 10}
+      ]}
+    );
+  });
+
+  it('should layout rtl with reverse correctly', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, direction: 'rtl', flexDirection: 'row-reverse'}, children: [
+        {style: {width: 100, height: 200}},
+        {style: {width: 300, height: 150}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 200, top: 0, left: 0},
+        {width: 300, height: 150, top: 0, left: 100}
+      ]}
+    );
+  });
+
   it('should layout node with row flex direction', function() {
     testLayout(
       {style: {width: 1000, height: 1000, flexDirection: 'row'}, children: [
@@ -123,6 +185,19 @@ describe('Layout', function() {
       {width: 1000, height: 1000, top: 0, left: 0, children: [
         {width: 100, height: 200, top: 0, left: 0},
         {width: 300, height: 150, top: 0, left: 100}
+      ]}
+    );
+  });
+
+  it('should layout node with row flex direction in rtl', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {width: 100, height: 200}},
+        {style: {width: 300, height: 150}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 200, top: 0, left: 900},
+        {width: 300, height: 150, top: 0, left: 600}
       ]}
     );
   });
@@ -140,6 +215,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node based on children main dimensions in reverse', function() {
+    testLayout(
+      {style: {width: 300, flexDirection: 'column-reverse'}, children: [
+        {style: {width: 100, height: 200}},
+        {style: {width: 300, height: 150}}
+      ]},
+      {width: 300, height: 350, top: 0, left: 0, children: [
+        {width: 100, height: 200, top: 150, left: 0},
+        {width: 300, height: 150, top: 0, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with just flex', function() {
     testLayout(
       {style: {width: 1000, height: 1000}, children: [
@@ -153,12 +241,44 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with just flex in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse'}, children: [
+        {style: {width: 100, height: 200}},
+        {style: {width: 100, flex: 1}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 200, top: 800, left: 0},
+        {width: 100, height: 800, top: 0, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with flex recursively', function() {
     testLayout(
       {style: {width: 1000, height: 1000}, children: [
         {style: {width: 1000, flex: 1}, children: [
           {style: {width: 1000, flex: 1}, children: [
             {style: {width: 1000, flex: 1}}
+          ]}
+        ]}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 1000, height: 1000, top: 0, left: 0, children: [
+          {width: 1000, height: 1000, top: 0, left: 0, children: [
+            {width: 1000, height: 1000, top: 0, left: 0}
+          ]}
+        ]}
+      ]}
+    );
+  });
+
+  it('should layout node with flex recursively in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse'}, children: [
+        {style: {width: 1000, flex: 1, flexDirection: 'column-reverse'}, children: [
+          {style: {width: 1000, flex: 1, flexDirection: 'column-reverse'}, children: [
+            {style: {width: 1000, flex: 1, flexDirection: 'column-reverse'}}
           ]}
         ]}
       ]},
@@ -185,6 +305,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with targeted margin in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', marginTop: 10, marginLeft: 5}, children: [
+        {style: {width: 100, height: 100, marginTop: 50, marginLeft: 15, marginBottom: 20}},
+        {style: {width: 100, height: 100, marginLeft: 30}}
+      ]},
+      {width: 1000, height: 1000, top: 10, left: 5, children: [
+        {width: 100, height: 100, top: 880, left: 15},
+        {width: 100, height: 100, top: 730, left: 30}
+      ]}
+    );
+  });
+
   it('should layout node with justifyContent: flex-start', function() {
     testLayout(
       {style: {width: 1000, height: 1000, justifyContent: 'flex-start'}, children: [
@@ -194,6 +327,19 @@ describe('Layout', function() {
       {width: 1000, height: 1000, top: 0, left: 0, children: [
         {width: 100, height: 100, top: 0, left: 0},
         {width: 100, height: 100, top: 100, left: 0}
+      ]}
+    );
+  });
+
+  it('should layout node with justifyContent: flex-start in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', justifyContent: 'flex-start'}, children: [
+        {style: {width: 100, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 100, top: 900, left: 0},
+        {width: 100, height: 100, top: 800, left: 0}
       ]}
     );
   });
@@ -211,6 +357,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with justifyContent: flex-end in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', justifyContent: 'flex-end'}, children: [
+        {style: {width: 100, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 100, top: 100, left: 0},
+        {width: 100, height: 100, top: 0, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with justifyContent: space-between', function() {
     testLayout(
       {style: {width: 1000, height: 1000, justifyContent: 'space-between'}, children: [
@@ -220,6 +379,19 @@ describe('Layout', function() {
       {width: 1000, height: 1000, top: 0, left: 0, children: [
         {width: 100, height: 100, top: 0, left: 0},
         {width: 100, height: 100, top: 900, left: 0}
+      ]}
+    );
+  });
+
+  it('should layout node with justifyContent: space-between in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', justifyContent: 'space-between'}, children: [
+        {style: {width: 100, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 100, top: 900, left: 0},
+        {width: 100, height: 100, top: 0, left: 0}
       ]}
     );
   });
@@ -237,6 +409,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with justifyContent: space-around in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', justifyContent: 'space-around'}, children: [
+        {style: {width: 100, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 100, top: 700, left: 0},
+        {width: 100, height: 100, top: 200, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with justifyContent: center', function() {
     testLayout(
       {style: {width: 1000, height: 1000, justifyContent: 'center'}, children: [
@@ -246,6 +431,19 @@ describe('Layout', function() {
       {width: 1000, height: 1000, top: 0, left: 0, children: [
         {width: 100, height: 100, top: 400, left: 0},
         {width: 100, height: 100, top: 500, left: 0}
+      ]}
+    );
+  });
+
+  it('should layout node with justifyContent: center in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', justifyContent: 'center'}, children: [
+        {style: {width: 100, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 100, height: 100, top: 500, left: 0},
+        {width: 100, height: 100, top: 400, left: 0}
       ]}
     );
   });
@@ -274,6 +472,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with alignItems: flex-start in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', alignItems: 'flex-start'}, children: [
+        {style: {width: 200, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 200, height: 100, top: 900, left: 0},
+        {width: 100, height: 100, top: 800, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with alignItems: center', function() {
     testLayout(
       {style: {width: 1000, height: 1000, alignItems: 'center'}, children: [
@@ -283,6 +494,19 @@ describe('Layout', function() {
       {width: 1000, height: 1000, top: 0, left: 0, children: [
         {width: 200, height: 100, top: 0, left: 400},
         {width: 100, height: 100, top: 100, left: 450}
+      ]}
+    );
+  });
+
+  it('should layout node with alignItems: center in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', alignItems: 'center'}, children: [
+        {style: {width: 200, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 200, height: 100, top: 900, left: 400},
+        {width: 100, height: 100, top: 800, left: 450}
       ]}
     );
   });
@@ -300,6 +524,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with alignItems: flex-end in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', alignItems: 'flex-end'}, children: [
+        {style: {width: 200, height: 100}},
+        {style: {width: 100, height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 200, height: 100, top: 900, left: 800},
+        {width: 100, height: 100, top: 800, left: 900}
+      ]}
+    );
+  });
+
   it('should layout node with alignSelf overrides alignItems', function() {
     testLayout(
       {style: {width: 1000, height: 1000, alignItems: 'flex-end'}, children: [
@@ -309,6 +546,19 @@ describe('Layout', function() {
       {width: 1000, height: 1000, top: 0, left: 0, children: [
         {width: 200, height: 100, top: 0, left: 800},
         {width: 100, height: 100, top: 100, left: 450}
+      ]}
+    );
+  });
+
+  it('should layout node with alignSelf overrides alignItems in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', alignItems: 'flex-end'}, children: [
+        {style: {width: 200, height: 100}},
+        {style: {width: 100, height: 100, alignSelf: 'center'}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 200, height: 100, top: 900, left: 800},
+        {width: 100, height: 100, top: 800, left: 450}
       ]}
     );
   });
@@ -324,9 +574,31 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with alignItem: stretch in reverse', function() {
+    testLayout(
+      {style: {width: 1000, height: 1000, flexDirection: 'column-reverse', alignItems: 'stretch'}, children: [
+        {style: {height: 100}}
+      ]},
+      {width: 1000, height: 1000, top: 0, left: 0, children: [
+        {width: 1000, height: 100, top: 900, left: 0}
+      ]}
+    );
+  });
+
   it('should layout empty node', function() {
     testLayout(
       {style: {}, children: [
+        {style: {}}
+      ]},
+      {width: 0, height: 0, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 0, left: 0}
+      ]}
+    );
+  });
+
+  it('should layout empty node in reverse', function() {
+    testLayout(
+      {style: {flexDirection: 'column-reverse'}, children: [
         {style: {}}
       ]},
       {width: 0, height: 0, top: 0, left: 0, children: [
@@ -346,6 +618,17 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout child with margin in reverse', function() {
+    testLayout(
+      {style: {flexDirection: 'column-reverse'}, children: [
+        {style: {margin: 5}}
+      ]},
+      {width: 10, height: 10, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 5, left: 5}
+      ]}
+    );
+  });
+
   it('should not shrink children if not enough space', function() {
     testLayout(
       {style: {height: 100}, children: [
@@ -355,6 +638,19 @@ describe('Layout', function() {
       {width: 0, height: 100, top: 0, left: 0, children: [
         {width: 0, height: 100, top: 0, left: 0},
         {width: 0, height: 200, top: 100, left: 0}
+      ]}
+    );
+  });
+
+  it('should not shrink children if not enough space in reverse', function() {
+    testLayout(
+      {style: {height: 100, flexDirection: 'column-reverse'}, children: [
+        {style: {height: 100}},
+        {style: {height: 200}}
+      ]},
+      {width: 0, height: 100, top: 0, left: 0, children: [
+        {width: 0, height: 100, top: 0, left: 0},
+        {width: 0, height: 200, top: -200, left: 0}
       ]}
     );
   });
@@ -377,6 +673,17 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout flex-end taking into account margin in reverse', function() {
+    testLayout(
+      {style: {height: 100, flexDirection: 'column-reverse', justifyContent: 'flex-end'}, children: [
+        {style: {marginTop: 10}}
+      ]},
+      {width: 0, height: 100, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 10, left: 0}
+      ]}
+    );
+  });
+
   it('should layout alignItems with margin', function() {
     testLayout(
       {style: {}, children: [
@@ -389,6 +696,23 @@ describe('Layout', function() {
         {width: 20, height: 120, top: 0, left: 0, children: [
           {width: 0, height: 0, top: 10, left: 10},
           {width: 0, height: 100, top: 20, left: 20}
+        ]}
+      ]}
+    );
+  });
+
+  it('should layout alignItems with margin in reverse', function() {
+    testLayout(
+      {style: {}, children: [
+        {style: {flexDirection: 'column-reverse', alignItems: 'flex-end'}, children: [
+          {style: {margin: 10}},
+          {style: {height: 100}}
+        ]}
+      ]},
+      {width: 20, height: 120, top: 0, left: 0, children: [
+        {width: 20, height: 120, top: 0, left: 0, children: [
+          {width: 0, height: 0, top: 110, left: 10},
+          {width: 0, height: 100, top: 0, left: 20}
         ]}
       ]}
     );
@@ -408,6 +732,17 @@ describe('Layout', function() {
   it('should layout alignItems stretch and margin', function() {
     testLayout(
       {style: {alignItems: 'stretch'}, children: [
+        {style: {marginLeft: 10}}
+      ]},
+      {width: 10, height: 0, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 0, left: 10}
+      ]}
+    );
+  });
+
+  it('should layout alignItems stretch and margin in reverse', function() {
+    testLayout(
+      {style: {flexDirection: 'column-reverse', alignItems: 'stretch'}, children: [
         {style: {marginLeft: 10}}
       ]},
       {width: 10, height: 0, top: 0, left: 0, children: [
@@ -652,6 +987,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with space-around and child position absolute in reverse', function() {
+    testLayout(
+      {style: {height: 200, flexDirection: 'column-reverse', justifyContent: 'space-around'}, children: [
+        {style: {position: 'absolute'}},
+        {style: {}}
+      ]},
+      {width: 0, height: 200, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 100, left: 0},
+        {width: 0, height: 0, top: 100, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with flex and main margin', function() {
     testLayout(
       {style: {width: 700, flexDirection: 'row'}, children: [
@@ -659,6 +1007,17 @@ describe('Layout', function() {
       ]},
       {width: 700, height: 0, top: 0, left: 0, children: [
         {width: 695, height: 0, top: 0, left: 5}
+      ]}
+    );
+  });
+
+  it('should layout node with flex and main margin in rtl', function() {
+    testLayout(
+      {style: {width: 700, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {marginRight: 5, flex: 1}}
+      ]},
+      {width: 700, height: 0, top: 0, left: 0, children: [
+        {width: 695, height: 0, top: 0, left: 0}
       ]}
     );
   });
@@ -676,6 +1035,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout node with multiple flex and padding in rtl', function() {
+    testLayout(
+      {style: {width: 700, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1}},
+        {style: {paddingLeft: 5, flex: 1}}
+      ]},
+      {width: 700, height: 0, top: 0, left: 0, children: [
+        {width: 347.5, height: 0, top: 0, left: 352.5},
+        {width: 352.5, height: 0, top: 0, left: 0}
+      ]}
+    );
+  });
+
   it('should layout node with multiple flex and margin', function() {
     testLayout(
       {style: {width: 700, flexDirection: 'row'}, children: [
@@ -685,6 +1057,19 @@ describe('Layout', function() {
       {width: 700, height: 0, top: 0, left: 0, children: [
         {width: 347.5, height: 0, top: 0, left: 0},
         {width: 347.5, height: 0, top: 0, left: 352.5}
+      ]}
+    );
+  });
+
+  it('should layout node with multiple flex and margin in rtl', function() {
+    testLayout(
+      {style: {width: 700, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1}},
+        {style: {marginRight: 5, flex: 1}}
+      ]},
+      {width: 700, height: 0, top: 0, left: 0, children: [
+        {width: 347.5, height: 0, top: 0, left: 352.5},
+        {width: 347.5, height: 0, top: 0, left: 0}
       ]}
     );
   });
@@ -709,6 +1094,17 @@ describe('Layout', function() {
       ]},
       {width: 600, height: 0, top: 0, left: 0, children: [
         {width: 0, height: 0, top: 0, left: 0}
+      ]}
+    );
+  });
+
+  it('should layout node with flex and position absolute in rtl', function() {
+    testLayout(
+      {style: {width: 600, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1, position: 'absolute'}}
+      ]},
+      {width: 600, height: 0, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 0, left: 600}
       ]}
     );
   });
@@ -788,6 +1184,17 @@ describe('Layout', function() {
     );
   });
 
+  it('should handle negative margin and min padding correctly in rtl', function() {
+    testLayout(
+      {style: {borderLeftWidth: 1, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {marginLeft: -8}}
+      ]},
+      {width: 1, height: 0, top: 0, left: 0, children: [
+        {width: 0, height: 0, top: 0, left: 1}
+      ]}
+    );
+  });
+
   it('should layout node with just text', function() {
     testLayout(
       {style: {measure: text(texts.small)}},
@@ -828,6 +1235,21 @@ describe('Layout', function() {
     testLayout(
       {style: {}, children: [
         {style: {width: 500, flexDirection: 'row'}, children: [
+          {style: {flex: 1, measure: text(texts.big)}}
+        ]}
+      ]},
+      {width: 500, height: textSizes.smallHeight, top: 0, left: 0, children: [
+        {width: 500, height: textSizes.smallHeight, top: 0, left: 0, children: [
+          {width: 500, height: textSizes.smallHeight, top: 0, left: 0}
+        ]}
+      ]}
+    );
+  });
+
+  it('should layout node with text and flex in rtl', function() {
+    testLayout(
+      {style: {}, children: [
+        {style: {width: 500, direction: 'rtl', flexDirection: 'row'}, children: [
           {style: {flex: 1, measure: text(texts.big)}}
         ]}
       ]},
@@ -908,6 +1330,19 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout space-between when remaining space is negative in reverse', function() {
+    testLayout(
+      {style: {height: 100, flexDirection: 'column-reverse', justifyContent: 'space-between'}, children: [
+        {style: {height: 900}},
+        {style: {}}
+      ]},
+      {width: 0, height: 100, top: 0, left: 0, children: [
+        {width: 0, height: 900, top: -800, left: 0},
+        {width: 0, height: 0, top: -800, left: 0}
+      ]}
+    );
+  });
+
   it('should layout flex-end when remaining space is negative', function() {
     testLayout(
       {style: {width: 200, flexDirection: 'row', justifyContent: 'flex-end'}, children: [
@@ -915,6 +1350,17 @@ describe('Layout', function() {
       ]},
       {width: 200, height: 0, top: 0, left: 0, children: [
         {width: 900, height: 0, top: 0, left: -700}
+      ]}
+    );
+  });
+
+  it('should layout flex-end when remaining space is negative in rtl', function() {
+    testLayout(
+      {style: {width: 200, direction: 'rtl', flexDirection: 'row', justifyContent: 'flex-end'}, children: [
+        {style: {width: 900}}
+      ]},
+      {width: 200, height: 0, top: 0, left: 0, children: [
+        {width: 900, height: 0, top: 0, left: 0}
       ]}
     );
   });
@@ -929,6 +1375,21 @@ describe('Layout', function() {
       {width: 200, height: textSizes.smallHeight + 40, top: 0, left: 0, children: [
         {width: 200, height: textSizes.smallHeight + 40, top: 0, left: 0, children: [
           {width: textSizes.bigWidth, height: textSizes.smallHeight, top: 20, left: 20}
+        ]}
+      ]}
+    );
+  });
+
+  it('should layout text with flexDirection row in rtl', function() {
+    testLayout(
+      {style: { direction: 'rtl' }, children: [
+        {style: {width: 200, flexDirection: 'row'}, children: [
+          {style: {margin: 20, measure: text(texts.big)}}
+        ]}
+      ]},
+      {width: 200, height: textSizes.smallHeight + 40, top: 0, left: 0, children: [
+        {width: 200, height: textSizes.smallHeight + 40, top: 0, left: 0, children: [
+          {width: textSizes.bigWidth, height: textSizes.smallHeight, top: 20, left: 7.578125}
         ]}
       ]}
     );
@@ -973,15 +1434,28 @@ describe('Layout', function() {
     );
   });
 
-  it('should layout with negative flex', function() {
+  it('should layout with arbitrary flex in reverse', function() {
     testLayout(
-      {style: {width: 100, height: 100, alignSelf: 'flex-start'}, children: [
+      {style: {width: 100, height: 100, flexDirection: 'column-reverse', alignSelf: 'flex-start'}, children: [
+        {style: {flex: 2.5, alignSelf: 'flex-start'}},
+        {style: {flex: 7.5, alignSelf: 'flex-start'}}
+      ]},
+      {width: 100, height: 100, top: 0, left: 0, children: [
+        {width: 0, height: 25, top: 75, left: 0},
+        {width: 0, height: 75, top: 0, left: 0}
+      ]}
+    );
+  });
+
+  it('should layout with negative flex in reverse', function() {
+    testLayout(
+      {style: {width: 100, height: 100, flexDirection: 'column-reverse', alignSelf: 'flex-start'}, children: [
         {style: {flex: -2.5, alignSelf: 'flex-start'}},
         {style: {flex: 0, alignSelf: 'flex-start'}}
       ]},
       {width: 100, height: 100, top: 0, left: 0, children: [
-        {width: 0, height: 0, top: 0, left: 0},
-        {width: 0, height: 0, top: 0, left: 0}
+        {width: 0, height: 0, top: 100, left: 0},
+        {width: 0, height: 0, top: 100, left: 0}
       ]}
     );
   });
@@ -1196,6 +1670,21 @@ describe('Layout', function() {
     );
   });
 
+  it('should layout flex-wrap in rtl', function() {
+    testLayout(
+      {style: {flexWrap: 'wrap', direction: 'rtl', flexDirection: 'row', width: 100}, children: [
+        {style: {width: 40, height: 10}},
+        {style: {width: 40, height: 10}},
+        {style: {width: 40, height: 10}}
+      ]},
+      {width: 100, height: 20, top: 0, left: 0, children: [
+        {width: 40, height: 10, top: 0, left: 60},
+        {width: 40, height: 10, top: 0, left: 20},
+        {width: 40, height: 10, top: 10, left: 60}
+      ]}
+    );
+  });
+
   it('should layout flex wrap with a line bigger than container', function() {
     testLayout(
       {style: {height: 100, flexWrap: 'wrap'}, children: [
@@ -1315,6 +1804,21 @@ describe('Layout', function() {
     );
   });
 
+  it('should override flex direction size with min bounds in rtl', function() {
+    testLayout(
+      {style: {width: 300, height: 200, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1}},
+        {style: {flex: 1, minWidth: 200}},
+        {style: {flex: 1}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 50, height: 200, top: 0, left: 250},
+        {width: 200, height: 200, top: 0, left: 50},
+        {width: 50, height: 200, top: 0, left: 0}
+      ]}
+    );
+  });
+
   it('should not override flex direction size within bounds', function() {
     testLayout(
       {style: {width: 300, height: 200, flexDirection: 'row'}, children: [
@@ -1326,6 +1830,21 @@ describe('Layout', function() {
         {width: 100, height: 200, top: 0, left: 0},
         {width: 100, height: 200, top: 0, left: 100},
         {width: 100, height: 200, top: 0, left: 200}
+      ]}
+    );
+  });
+
+  it('should not override flex direction size within bounds in rtl', function() {
+    testLayout(
+      {style: {width: 300, height: 200, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1}},
+        {style: {flex: 1, minWidth: 90, maxWidth: 110}},
+        {style: {flex: 1}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 100, height: 200, top: 0, left: 200},
+        {width: 100, height: 200, top: 0, left: 100},
+        {width: 100, height: 200, top: 0, left: 0}
       ]}
     );
   });
@@ -1345,6 +1864,21 @@ describe('Layout', function() {
     );
   });
 
+  it('should override flex direction size with max bounds in rtl', function() {
+    testLayout(
+      {style: {width: 300, height: 200, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1}},
+        {style: {flex: 1, maxWidth: 60}},
+        {style: {flex: 1}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 120, height: 200, top: 0, left: 180},
+        {width: 60, height: 200, top: 0, left: 120},
+        {width: 120, height: 200, top: 0, left: 0}
+      ]}
+    );
+  });
+
   it('should ignore flex size if fully max bound', function() {
     testLayout(
       {style: {width: 300, height: 200, flexDirection: 'row'}, children: [
@@ -1355,6 +1889,21 @@ describe('Layout', function() {
       {width: 300, height: 200, top: 0, left: 0, children: [
         {width: 60, height: 200, top: 0, left: 0},
         {width: 60, height: 200, top: 0, left: 60},
+        {width: 60, height: 200, top: 0, left: 120}
+      ]}
+    );
+  });
+
+  it('should ignore flex size if fully max bound in rtl', function() {
+    testLayout(
+      {style: {width: 300, height: 200, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1, maxWidth: 60}},
+        {style: {flex: 1, maxWidth: 60}},
+        {style: {flex: 1, maxWidth: 60}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 60, height: 200, top: 0, left: 240},
+        {width: 60, height: 200, top: 0, left: 180},
         {width: 60, height: 200, top: 0, left: 120}
       ]}
     );
@@ -1371,6 +1920,21 @@ describe('Layout', function() {
         {width: 120, height: 200, top: 0, left: 0},
         {width: 120, height: 200, top: 0, left: 120},
         {width: 120, height: 200, top: 0, left: 240}
+      ]}
+    );
+  });
+
+  it('should ignore flex size if fully min bound in rtl', function() {
+    testLayout(
+      {style: {width: 300, height: 200, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {flex: 1, minWidth: 120}},
+        {style: {flex: 1, minWidth: 120}},
+        {style: {flex: 1, minWidth: 120}}
+      ]},
+      {width: 300, height: 200, top: 0, left: 0, children: [
+        {width: 120, height: 200, top: 0, left: 180},
+        {width: 120, height: 200, top: 0, left: 60},
+        {width: 120, height: 200, top: 0, left: -60}
       ]}
     );
   });
@@ -1491,6 +2055,17 @@ describe('Layout', function() {
     );
   });
 
+  it('should keep cross axis size within min bounds in rtl', function() {
+    testLayout(
+      {style: {width: 1000, direction: 'rtl', flexDirection: 'row'}, children: [
+        {style: {height: 100, minHeight: 110, minWidth: 100}}
+      ]},
+      {width: 1000, height: 110, top: 0, left: 0, children: [
+        {width: 100, height: 110, top: 0, left: 900}
+      ]}
+    );
+  });
+
   it('should layout node with position absolute, top and left and max bounds', function() {
     testLayout(
       {style: {width: 1000, height: 1000}, children: [
@@ -1586,5 +2161,28 @@ describe('Layout', function() {
     );
   });
 
-
+  it('should layout nested nodes with mixed directions', function() {
+    testLayout(
+      {style: {width: 200, height: 200, direction: 'rtl'}, children: [
+        {style: {flexDirection: 'row'}, children: [
+          {style: {width: 50, height: 50}},
+          {style: {width: 50, height: 50}}
+        ]},
+        {style: {direction: 'ltr', flexDirection: 'row'}, children: [
+          {style: {width: 50, height: 50}},
+          {style: {width: 50, height: 50}}
+        ]}
+      ]},
+      {width: 200, height: 200, top: 0, left: 0, children: [
+        {width: 200, height: 50, top: 0, left: 0, children: [
+          {width: 50, height: 50, top: 0, left: 150},
+          {width: 50, height: 50, top: 0, left: 100}
+        ]},
+        {width: 200, height: 50, top: 50, left: 0, children: [
+          {width: 50, height: 50, top: 0, left: 0},
+          {width: 50, height: 50, top: 0, left: 50}
+        ]}
+      ]}
+    );
+  });
 });

--- a/src/java/src/com/facebook/csslayout/CSSDirection.java
+++ b/src/java/src/com/facebook/csslayout/CSSDirection.java
@@ -8,9 +8,8 @@
  */
 package com.facebook.csslayout;
 
-public enum CSSFlexDirection {
-  COLUMN,
-  COLUMN_REVERSE,
-  ROW,
-  ROW_REVERSE
+public enum CSSDirection {
+  INHERIT,
+  LTR,
+  RTL,
 }

--- a/src/java/src/com/facebook/csslayout/CSSLayout.java
+++ b/src/java/src/com/facebook/csslayout/CSSLayout.java
@@ -13,8 +13,10 @@ package com.facebook.csslayout;
  */
 public class CSSLayout {
 
-  public float x;
-  public float y;
+  public float top;
+  public float left;
+  public float right;
+  public float bottom;
   public float width = CSSConstants.UNDEFINED;
   public float height = CSSConstants.UNDEFINED;
 
@@ -22,15 +24,19 @@ public class CSSLayout {
    * This should always get called before calling {@link LayoutEngine#layoutNode(CSSNode, float)}
    */
   public void resetResult() {
-    x = 0;
-    y = 0;
+    left = 0;
+    top = 0;
+    right = 0;
+    bottom = 0;
     width = CSSConstants.UNDEFINED;
     height = CSSConstants.UNDEFINED;
   }
 
   public void copy(CSSLayout layout) {
-    x = layout.x;
-    y = layout.y;
+    left = layout.left;
+    top = layout.top;
+    right = layout.right;
+    bottom = layout.bottom;
     width = layout.width;
     height = layout.height;
   }
@@ -38,8 +44,8 @@ public class CSSLayout {
   @Override
   public String toString() {
     return "layout: {" +
-        "x: " + x + ", " +
-        "y: " + y + ", " +
+        "left: " + left + ", " +
+        "top: " + top + ", " +
         "width: " + width + ", " +
         "height: " + height +
         "}";

--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -125,7 +125,7 @@ public class CSSNode {
    */
   public void calculateLayout(CSSLayoutContext layoutContext) {
     layout.resetResult();
-    LayoutEngine.layoutNode(layoutContext, this, CSSConstants.UNDEFINED);
+    LayoutEngine.layoutNode(layoutContext, this, CSSConstants.UNDEFINED, null);
   }
 
   /**
@@ -328,11 +328,11 @@ public class CSSNode {
   }
 
   public float getLayoutX() {
-    return layout.x;
+    return layout.left;
   }
 
   public float getLayoutY() {
-    return layout.y;
+    return layout.top;
   }
 
   public float getLayoutWidth() {

--- a/src/java/src/com/facebook/csslayout/CSSStyle.java
+++ b/src/java/src/com/facebook/csslayout/CSSStyle.java
@@ -13,6 +13,7 @@ package com.facebook.csslayout;
  */
 public class CSSStyle {
 
+  public CSSDirection direction = CSSDirection.INHERIT;
   public CSSFlexDirection flexDirection = CSSFlexDirection.COLUMN;
   public CSSJustify justifyContent = CSSJustify.FLEX_START;
   public CSSAlign alignItems = CSSAlign.STRETCH;

--- a/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
+++ b/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
@@ -69,8 +69,8 @@ public class LayoutEngineTest {
 
   private static boolean areLayoutsEqual(CSSNode a, CSSNode b) {
     boolean doNodesHaveSameLayout =
-        areFloatsEqual(a.layout.x, b.layout.x) &&
-        areFloatsEqual(a.layout.y, b.layout.y) &&
+        areFloatsEqual(a.layout.left, b.layout.left) &&
+        areFloatsEqual(a.layout.top, b.layout.top) &&
         areFloatsEqual(a.layout.width, b.layout.width) &&
         areFloatsEqual(a.layout.height, b.layout.height);
     if (!doNodesHaveSameLayout) {
@@ -102,8 +102,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 200;
     }
@@ -137,26 +137,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 500;
         node_1.layout.height = 500;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 500;
-        node_1.layout.x = 0;
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
         node_1.layout.width = 250;
         node_1.layout.height = 250;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 750;
-        node_1.layout.x = 0;
+        node_1.layout.top = 750;
+        node_1.layout.left = 0;
         node_1.layout.width = 125;
         node_1.layout.height = 125;
       }
@@ -167,6 +167,61 @@ public class LayoutEngineTest {
 
   @Test
   public void testCase2()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 500;
+        node_1.style.height = 500;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 250;
+        node_1.style.height = 250;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.width = 125;
+        node_1.style.height = 125;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
+        node_1.layout.width = 500;
+        node_1.layout.height = 500;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 250;
+        node_1.layout.left = 0;
+        node_1.layout.width = 250;
+        node_1.layout.height = 250;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 125;
+        node_1.layout.left = 0;
+        node_1.layout.width = 125;
+        node_1.layout.height = 125;
+      }
+    }
+
+    test("should layout node with children in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase3()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -198,34 +253,34 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 500;
         node_1.layout.height = 500;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 500;
-        node_1.layout.x = 0;
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
         node_1.layout.width = 500;
         node_1.layout.height = 500;
         addChildren(node_1, 2);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 250;
           node_2.layout.height = 250;
           node_2 = node_1.getChildAt(1);
-          node_2.layout.y = 250;
-          node_2.layout.x = 0;
+          node_2.layout.top = 250;
+          node_2.layout.left = 0;
           node_2.layout.width = 250;
           node_2.layout.height = 250;
         }
@@ -236,7 +291,79 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase3()
+  public void testCase4()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 500;
+        node_1.style.height = 500;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+        node_1.style.width = 500;
+        node_1.style.height = 500;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.width = 250;
+          node_2.style.height = 250;
+          node_2 = node_1.getChildAt(1);
+          node_2.style.width = 250;
+          node_2.style.height = 250;
+        }
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
+        node_1.layout.width = 500;
+        node_1.layout.height = 500;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 500;
+        node_1.layout.height = 500;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 250;
+          node_2.layout.left = 0;
+          node_2.layout.width = 250;
+          node_2.layout.height = 250;
+          node_2 = node_1.getChildAt(1);
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
+          node_2.layout.width = 250;
+          node_2.layout.height = 250;
+        }
+      }
+    }
+
+    test("should layout node with nested children in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase5()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -252,8 +379,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 10;
-      node_0.layout.x = 10;
+      node_0.layout.top = 10;
+      node_0.layout.left = 10;
       node_0.layout.width = 100;
       node_0.layout.height = 200;
     }
@@ -262,7 +389,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase4()
+  public void testCase6()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -303,26 +430,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 10;
-      node_0.layout.x = 10;
+      node_0.layout.top = 10;
+      node_0.layout.left = 10;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 50;
-        node_1.layout.x = 50;
+        node_1.layout.top = 50;
+        node_1.layout.left = 50;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 225;
-        node_1.layout.x = 25;
+        node_1.layout.top = 225;
+        node_1.layout.left = 25;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 360;
-        node_1.layout.x = 10;
+        node_1.layout.top = 360;
+        node_1.layout.left = 10;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -332,7 +459,126 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase5()
+  public void testCase7()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      node_0.style.margin[Spacing.LEFT] = 10;
+      node_0.style.margin[Spacing.TOP] = 10;
+      node_0.style.margin[Spacing.RIGHT] = 10;
+      node_0.style.margin[Spacing.BOTTOM] = 10;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1.style.margin[Spacing.LEFT] = 50;
+        node_1.style.margin[Spacing.TOP] = 50;
+        node_1.style.margin[Spacing.RIGHT] = 50;
+        node_1.style.margin[Spacing.BOTTOM] = 50;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1.style.margin[Spacing.LEFT] = 25;
+        node_1.style.margin[Spacing.TOP] = 25;
+        node_1.style.margin[Spacing.RIGHT] = 25;
+        node_1.style.margin[Spacing.BOTTOM] = 25;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1.style.margin[Spacing.LEFT] = 10;
+        node_1.style.margin[Spacing.TOP] = 10;
+        node_1.style.margin[Spacing.RIGHT] = 10;
+        node_1.style.margin[Spacing.BOTTOM] = 10;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 10;
+      node_0.layout.left = 10;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 850;
+        node_1.layout.left = 50;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 675;
+        node_1.layout.left = 25;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 540;
+        node_1.layout.left = 10;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with several children in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase8()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 300;
+        node_1.style.height = 150;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 100;
+        node_1.layout.width = 300;
+        node_1.layout.height = 150;
+      }
+    }
+
+    test("should layout rtl with reverse correctly", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase9()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -355,21 +601,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 100;
+        node_1.layout.top = 0;
+        node_1.layout.left = 100;
         node_1.layout.width = 300;
         node_1.layout.height = 150;
       }
@@ -379,7 +625,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase6()
+  public void testCase10()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 300;
+        node_1.style.height = 150;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 900;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 600;
+        node_1.layout.width = 300;
+        node_1.layout.height = 150;
+      }
+    }
+
+    test("should layout node with row flex direction in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase11()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -400,21 +694,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 350;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 200;
-        node_1.layout.x = 0;
+        node_1.layout.top = 200;
+        node_1.layout.left = 0;
         node_1.layout.width = 300;
         node_1.layout.height = 150;
       }
@@ -424,7 +718,53 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase7()
+  public void testCase12()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 300;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 300;
+        node_1.style.height = 150;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 350;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 150;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 300;
+        node_1.layout.height = 150;
+      }
+    }
+
+    test("should layout node based on children main dimensions in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase13()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -446,21 +786,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 200;
-        node_1.layout.x = 0;
+        node_1.layout.top = 200;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 800;
       }
@@ -470,7 +810,54 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase8()
+  public void testCase14()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.width = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 800;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 800;
+      }
+    }
+
+    test("should layout node with just flex in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase15()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -503,32 +890,32 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 1000;
         node_1.layout.height = 1000;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 1000;
           node_2.layout.height = 1000;
           addChildren(node_2, 1);
           {
             TestCSSNode node_3;
             node_3 = node_2.getChildAt(0);
-            node_3.layout.y = 0;
-            node_3.layout.x = 0;
+            node_3.layout.top = 0;
+            node_3.layout.left = 0;
             node_3.layout.width = 1000;
             node_3.layout.height = 1000;
           }
@@ -540,7 +927,81 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase9()
+  public void testCase16()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+        node_1.style.flex = 1;
+        node_1.style.width = 1000;
+        addChildren(node_1, 1);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+          node_2.style.flex = 1;
+          node_2.style.width = 1000;
+          addChildren(node_2, 1);
+          {
+            TestCSSNode node_3;
+            node_3 = node_2.getChildAt(0);
+            node_3.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+            node_3.style.flex = 1;
+            node_3.style.width = 1000;
+          }
+        }
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 1000;
+        node_1.layout.height = 1000;
+        addChildren(node_1, 1);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
+          node_2.layout.width = 1000;
+          node_2.layout.height = 1000;
+          addChildren(node_2, 1);
+          {
+            TestCSSNode node_3;
+            node_3 = node_2.getChildAt(0);
+            node_3.layout.top = 0;
+            node_3.layout.left = 0;
+            node_3.layout.width = 1000;
+            node_3.layout.height = 1000;
+          }
+        }
+      }
+    }
+
+    test("should layout node with flex recursively in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase17()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -568,21 +1029,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 10;
-      node_0.layout.x = 5;
+      node_0.layout.top = 10;
+      node_0.layout.left = 5;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 50;
-        node_1.layout.x = 15;
+        node_1.layout.top = 50;
+        node_1.layout.left = 15;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 170;
-        node_1.layout.x = 30;
+        node_1.layout.top = 170;
+        node_1.layout.left = 30;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -592,7 +1053,60 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase10()
+  public void testCase18()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      node_0.style.margin[Spacing.LEFT] = 5;
+      node_0.style.margin[Spacing.TOP] = 10;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1.style.margin[Spacing.LEFT] = 15;
+        node_1.style.margin[Spacing.TOP] = 50;
+        node_1.style.margin[Spacing.BOTTOM] = 20;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1.style.margin[Spacing.LEFT] = 30;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 10;
+      node_0.layout.left = 5;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 880;
+        node_1.layout.left = 15;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 730;
+        node_1.layout.left = 30;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with targeted margin in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase19()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -615,21 +1129,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -639,7 +1153,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase11()
+  public void testCase20()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.FLEX_START;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 800;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: flex-start in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase21()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -662,21 +1224,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 800;
-        node_1.layout.x = 0;
+        node_1.layout.top = 800;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 900;
-        node_1.layout.x = 0;
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -686,7 +1248,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase12()
+  public void testCase22()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.FLEX_END;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: flex-end in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase23()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -709,21 +1319,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 900;
-        node_1.layout.x = 0;
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -733,7 +1343,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase13()
+  public void testCase24()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.SPACE_BETWEEN;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: space-between in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase25()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -756,21 +1414,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 200;
-        node_1.layout.x = 0;
+        node_1.layout.top = 200;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 700;
-        node_1.layout.x = 0;
+        node_1.layout.top = 700;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -780,7 +1438,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase14()
+  public void testCase26()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.SPACE_AROUND;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 700;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 200;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: space-around in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase27()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -803,21 +1509,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 400;
-        node_1.layout.x = 0;
+        node_1.layout.top = 400;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 500;
-        node_1.layout.x = 0;
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -827,7 +1533,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase15()
+  public void testCase28()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.CENTER;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 400;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with justifyContent: center in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase29()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -847,16 +1601,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 1000;
       }
@@ -866,7 +1620,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase16()
+  public void testCase30()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -889,21 +1643,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -913,7 +1667,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase17()
+  public void testCase31()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignItems = CSSAlign.FLEX_START;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 200;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
+        node_1.layout.width = 200;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 800;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with alignItems: flex-start in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase32()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -936,21 +1738,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 400;
+        node_1.layout.top = 0;
+        node_1.layout.left = 400;
         node_1.layout.width = 200;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 450;
+        node_1.layout.top = 100;
+        node_1.layout.left = 450;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -960,7 +1762,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase18()
+  public void testCase33()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignItems = CSSAlign.CENTER;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 200;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 400;
+        node_1.layout.width = 200;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 800;
+        node_1.layout.left = 450;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with alignItems: center in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase34()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -983,21 +1833,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 800;
+        node_1.layout.top = 0;
+        node_1.layout.left = 800;
         node_1.layout.width = 200;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 900;
+        node_1.layout.top = 100;
+        node_1.layout.left = 900;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -1007,7 +1857,55 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase19()
+  public void testCase35()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignItems = CSSAlign.FLEX_END;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 200;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 800;
+        node_1.layout.width = 200;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 800;
+        node_1.layout.left = 900;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with alignItems: flex-end in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase36()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1031,21 +1929,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 800;
+        node_1.layout.top = 0;
+        node_1.layout.left = 800;
         node_1.layout.width = 200;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 450;
+        node_1.layout.top = 100;
+        node_1.layout.left = 450;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -1055,7 +1953,56 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase20()
+  public void testCase37()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignItems = CSSAlign.FLEX_END;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 200;
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.alignSelf = CSSAlign.CENTER;
+        node_1.style.width = 100;
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 800;
+        node_1.layout.width = 200;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 800;
+        node_1.layout.left = 450;
+        node_1.layout.width = 100;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with alignSelf overrides alignItems in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase38()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1074,16 +2021,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 1000;
         node_1.layout.height = 100;
       }
@@ -1093,7 +2040,46 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase21()
+  public void testCase39()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignItems = CSSAlign.STRETCH;
+      node_0.style.width = 1000;
+      node_0.style.height = 1000;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.height = 100;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 1000;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
+        node_1.layout.width = 1000;
+        node_1.layout.height = 100;
+      }
+    }
+
+    test("should layout node with alignItem: stretch in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase40()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1108,16 +2094,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1127,7 +2113,42 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase22()
+  public void testCase41()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 0;
+      node_0.layout.height = 0;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout empty node in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase42()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1146,16 +2167,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 10;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 5;
-        node_1.layout.x = 5;
+        node_1.layout.top = 5;
+        node_1.layout.left = 5;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1165,7 +2186,46 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase23()
+  public void testCase43()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.margin[Spacing.LEFT] = 5;
+        node_1.style.margin[Spacing.TOP] = 5;
+        node_1.style.margin[Spacing.RIGHT] = 5;
+        node_1.style.margin[Spacing.BOTTOM] = 5;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 10;
+      node_0.layout.height = 10;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 5;
+        node_1.layout.left = 5;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout child with margin in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase44()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1184,21 +2244,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 200;
       }
@@ -1208,7 +2268,51 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase24()
+  public void testCase45()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.height = 100;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.height = 200;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 0;
+      node_0.layout.height = 100;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 100;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = -200;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should not shrink children if not enough space in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase46()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1219,8 +2323,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
     }
@@ -1229,7 +2333,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase25()
+  public void testCase47()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1247,16 +2351,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1266,7 +2370,45 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase26()
+  public void testCase48()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.FLEX_END;
+      node_0.style.height = 100;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.margin[Spacing.TOP] = 10;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 0;
+      node_0.layout.height = 100;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 10;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout flex-end taking into account margin in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase49()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1293,29 +2435,29 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 20;
       node_0.layout.height = 120;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 20;
         node_1.layout.height = 120;
         addChildren(node_1, 2);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 10;
-          node_2.layout.x = 10;
+          node_2.layout.top = 10;
+          node_2.layout.left = 10;
           node_2.layout.width = 0;
           node_2.layout.height = 0;
           node_2 = node_1.getChildAt(1);
-          node_2.layout.y = 20;
-          node_2.layout.x = 20;
+          node_2.layout.top = 20;
+          node_2.layout.left = 20;
           node_2.layout.width = 0;
           node_2.layout.height = 100;
         }
@@ -1326,7 +2468,68 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase27()
+  public void testCase50()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+        node_1.style.alignItems = CSSAlign.FLEX_END;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.margin[Spacing.LEFT] = 10;
+          node_2.style.margin[Spacing.TOP] = 10;
+          node_2.style.margin[Spacing.RIGHT] = 10;
+          node_2.style.margin[Spacing.BOTTOM] = 10;
+          node_2 = node_1.getChildAt(1);
+          node_2.style.height = 100;
+        }
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 20;
+      node_0.layout.height = 120;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 20;
+        node_1.layout.height = 120;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 110;
+          node_2.layout.left = 10;
+          node_2.layout.width = 0;
+          node_2.layout.height = 0;
+          node_2 = node_1.getChildAt(1);
+          node_2.layout.top = 0;
+          node_2.layout.left = 20;
+          node_2.layout.width = 0;
+          node_2.layout.height = 100;
+        }
+      }
+    }
+
+    test("should layout alignItems with margin in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase51()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1342,16 +2545,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1361,7 +2564,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase28()
+  public void testCase52()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1378,16 +2581,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 10;
+        node_1.layout.top = 0;
+        node_1.layout.left = 10;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1397,7 +2600,44 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase29()
+  public void testCase53()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignItems = CSSAlign.STRETCH;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.margin[Spacing.LEFT] = 10;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 10;
+      node_0.layout.height = 0;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 10;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout alignItems stretch and margin in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase54()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1411,8 +2651,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 10;
     }
@@ -1421,7 +2661,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase30()
+  public void testCase55()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1440,16 +2680,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 10;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 5;
-        node_1.layout.x = 5;
+        node_1.layout.top = 5;
+        node_1.layout.left = 5;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1459,7 +2699,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase31()
+  public void testCase56()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1482,16 +2722,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 20;
       node_0.layout.height = 20;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 10;
-        node_1.layout.x = 10;
+        node_1.layout.top = 10;
+        node_1.layout.left = 10;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1501,7 +2741,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase32()
+  public void testCase57()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1521,16 +2761,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 20;
       node_0.layout.height = 20;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 20;
         node_1.layout.height = 20;
       }
@@ -1540,7 +2780,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase33()
+  public void testCase58()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1564,16 +2804,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 120;
       node_0.layout.height = 120;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 50;
-        node_1.layout.x = 50;
+        node_1.layout.top = 50;
+        node_1.layout.left = 50;
         node_1.layout.width = 20;
         node_1.layout.height = 20;
       }
@@ -1583,7 +2823,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase34()
+  public void testCase59()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1608,24 +2848,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 32;
       node_0.layout.height = 32;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 32;
         node_1.layout.height = 32;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 16;
-          node_2.layout.x = 16;
+          node_2.layout.top = 16;
+          node_2.layout.left = 16;
           node_2.layout.width = 0;
           node_2.layout.height = 0;
         }
@@ -1636,7 +2876,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase35()
+  public void testCase60()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1648,8 +2888,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 5;
-      node_0.layout.x = 5;
+      node_0.layout.top = 5;
+      node_0.layout.left = 5;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
     }
@@ -1658,7 +2898,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase36()
+  public void testCase61()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1676,16 +2916,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 10;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 7.5f;
-        node_1.layout.x = 0;
+        node_1.layout.top = 7.5f;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1695,7 +2935,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase37()
+  public void testCase62()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1706,8 +2946,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = -5;
-      node_0.layout.x = 0;
+      node_0.layout.top = -5;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
     }
@@ -1716,7 +2956,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase38()
+  public void testCase63()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1728,8 +2968,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 10;
-      node_0.layout.x = 0;
+      node_0.layout.top = 10;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
     }
@@ -1738,7 +2978,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase39()
+  public void testCase64()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1761,26 +3001,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 500;
       node_0.layout.height = 0;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 250;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 250;
+        node_1.layout.top = 0;
+        node_1.layout.left = 250;
         node_1.layout.width = 50;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 0;
-        node_1.layout.x = 250;
+        node_1.layout.top = 0;
+        node_1.layout.left = 250;
         node_1.layout.width = 250;
         node_1.layout.height = 0;
       }
@@ -1790,7 +3030,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase40()
+  public void testCase65()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1807,16 +3047,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -1826,7 +3066,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase41()
+  public void testCase66()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1844,16 +3084,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 12;
         node_1.layout.height = 0;
       }
@@ -1863,7 +3103,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase42()
+  public void testCase67()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1875,8 +3115,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 20;
     }
@@ -1885,7 +3125,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase43()
+  public void testCase68()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1897,8 +3137,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 20;
       node_0.layout.height = 0;
     }
@@ -1907,7 +3147,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase44()
+  public void testCase69()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1931,30 +3171,30 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 400;
       node_0.layout.height = 0;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 400;
         node_1.layout.height = 0;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 400;
           node_2.layout.height = 0;
         }
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 0;
       }
@@ -1964,7 +3204,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase45()
+  public void testCase70()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -1984,16 +3224,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 10;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 5;
-        node_1.layout.x = 5;
+        node_1.layout.top = 5;
+        node_1.layout.left = 5;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2003,7 +3243,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase46()
+  public void testCase71()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2023,21 +3263,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 10;
-        node_1.layout.x = 10;
+        node_1.layout.top = 10;
+        node_1.layout.left = 10;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2047,7 +3287,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase47()
+  public void testCase72()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2068,16 +3308,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 40;
       node_0.layout.height = 40;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 20;
-        node_1.layout.x = 5;
+        node_1.layout.top = 20;
+        node_1.layout.left = 5;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2087,7 +3327,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase48()
+  public void testCase73()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2105,16 +3345,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 10;
-        node_1.layout.x = 0;
+        node_1.layout.top = 10;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2124,7 +3364,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase49()
+  public void testCase74()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2142,16 +3382,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 10;
+        node_1.layout.top = 0;
+        node_1.layout.left = 10;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2161,7 +3401,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase50()
+  public void testCase75()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2180,21 +3420,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 200;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2204,7 +3444,51 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase51()
+  public void testCase76()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.SPACE_AROUND;
+      node_0.style.height = 200;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.positionType = CSSPositionType.ABSOLUTE;
+        node_1 = node_0.getChildAt(1);
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 0;
+      node_0.layout.height = 200;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout node with space-around and child position absolute in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase77()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2223,16 +3507,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 700;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 5;
+        node_1.layout.top = 0;
+        node_1.layout.left = 5;
         node_1.layout.width = 695;
         node_1.layout.height = 0;
       }
@@ -2242,7 +3526,46 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase52()
+  public void testCase78()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 700;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1.style.margin[Spacing.RIGHT] = 5;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 700;
+      node_0.layout.height = 0;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 695;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout node with flex and main margin in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase79()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2263,21 +3586,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 700;
       node_0.layout.height = 0;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 347.5f;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 347.5f;
+        node_1.layout.top = 0;
+        node_1.layout.left = 347.5f;
         node_1.layout.width = 352.5f;
         node_1.layout.height = 0;
       }
@@ -2287,7 +3610,53 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase53()
+  public void testCase80()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 700;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.padding[Spacing.LEFT] = 5;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 700;
+      node_0.layout.height = 0;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 352.5f;
+        node_1.layout.width = 347.5f;
+        node_1.layout.height = 0;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 352.5f;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout node with multiple flex and padding in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase81()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2308,21 +3677,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 700;
       node_0.layout.height = 0;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 347.5f;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 352.5f;
+        node_1.layout.top = 0;
+        node_1.layout.left = 352.5f;
         node_1.layout.width = 347.5f;
         node_1.layout.height = 0;
       }
@@ -2332,7 +3701,53 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase54()
+  public void testCase82()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 700;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.margin[Spacing.RIGHT] = 5;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 700;
+      node_0.layout.height = 0;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 352.5f;
+        node_1.layout.width = 347.5f;
+        node_1.layout.height = 0;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 347.5f;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout node with multiple flex and margin in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase83()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2351,21 +3766,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 300;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 600;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 600;
-        node_1.layout.x = 0;
+        node_1.layout.top = 600;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2375,7 +3790,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase55()
+  public void testCase84()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2394,16 +3809,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 600;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2413,7 +3828,46 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase56()
+  public void testCase85()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 600;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.positionType = CSSPositionType.ABSOLUTE;
+        node_1.style.flex = 1;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 600;
+      node_0.layout.height = 0;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 600;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout node with flex and position absolute in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase86()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2433,21 +3887,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 500;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 500;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 500;
-        node_1.layout.x = 0;
+        node_1.layout.top = 500;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2457,7 +3911,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase57()
+  public void testCase87()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2471,8 +3925,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 10;
     }
@@ -2481,7 +3935,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase58()
+  public void testCase88()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2499,16 +3953,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 1;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2518,7 +3972,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase59()
+  public void testCase89()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2539,16 +3993,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 2;
       node_0.layout.height = 2;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 1;
-        node_1.layout.x = 6;
+        node_1.layout.top = 1;
+        node_1.layout.left = 6;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2558,7 +4012,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase60()
+  public void testCase90()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2580,16 +4034,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 50;
       node_0.layout.height = 40;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 20;
+        node_1.layout.top = 0;
+        node_1.layout.left = 20;
         node_1.layout.width = 40;
         node_1.layout.height = 40;
       }
@@ -2599,7 +4053,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase61()
+  public void testCase91()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2616,16 +4070,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 5;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 5;
         node_1.layout.height = 0;
       }
@@ -2635,7 +4089,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase62()
+  public void testCase92()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2653,16 +4107,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -2672,7 +4126,45 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase63()
+  public void testCase93()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.border[Spacing.LEFT] = 1;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.margin[Spacing.LEFT] = -8;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1;
+      node_0.layout.height = 0;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 1;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should handle negative margin and min padding correctly in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase94()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2684,8 +4176,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 34.671875f;
       node_0.layout.height = 18;
     }
@@ -2694,7 +4186,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase64()
+  public void testCase95()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2707,8 +4199,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 10;
       node_0.layout.height = 18;
     }
@@ -2717,7 +4209,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase65()
+  public void testCase96()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2729,8 +4221,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 172.421875f;
       node_0.layout.height = 18;
     }
@@ -2739,7 +4231,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase66()
+  public void testCase97()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2762,24 +4254,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 300;
         node_1.layout.height = 0;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 300;
           node_2.layout.height = 0;
         }
@@ -2790,7 +4282,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase67()
+  public void testCase98()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2815,24 +4307,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 500;
       node_0.layout.height = 18;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 500;
         node_1.layout.height = 18;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 500;
           node_2.layout.height = 18;
         }
@@ -2843,7 +4335,61 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase68()
+  public void testCase99()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.direction = CSSDirection.RTL;
+        node_1.style.flexDirection = CSSFlexDirection.ROW;
+        node_1.style.width = 500;
+        addChildren(node_1, 1);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.flex = 1;
+          node_2.setMeasureFunction(sTestMeasureFunction);
+          node_2.context = "loooooooooong with space";
+        }
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 500;
+      node_0.layout.height = 18;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 500;
+        node_1.layout.height = 18;
+        addChildren(node_1, 1);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
+          node_2.layout.width = 500;
+          node_2.layout.height = 18;
+        }
+      }
+    }
+
+    test("should layout node with text and flex in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase100()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2868,24 +4414,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 130;
       node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 130;
         node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 130;
           node_2.layout.height = 36;
         }
@@ -2896,7 +4442,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase69()
+  public void testCase101()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2922,24 +4468,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 200;
       node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 130;
           node_2.layout.height = 36;
         }
@@ -2950,7 +4496,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase70()
+  public void testCase102()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -2970,16 +4516,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100.4375f;
         node_1.layout.height = 36;
       }
@@ -2989,7 +4535,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase71()
+  public void testCase103()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3022,24 +4568,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 76;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 20;
-        node_1.layout.x = 20;
+        node_1.layout.top = 20;
+        node_1.layout.left = 20;
         node_1.layout.width = 100.4375f;
         node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 100.4375f;
           node_2.layout.height = 36;
         }
@@ -3050,7 +4596,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase72()
+  public void testCase104()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3069,21 +4615,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 900;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 900;
-        node_1.layout.x = 0;
+        node_1.layout.top = 900;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -3093,7 +4639,51 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase73()
+  public void testCase105()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.justifyContent = CSSJustify.SPACE_BETWEEN;
+      node_0.style.height = 100;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.height = 900;
+        node_1 = node_0.getChildAt(1);
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 0;
+      node_0.layout.height = 100;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = -800;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 900;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = -800;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout space-between when remaining space is negative in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase106()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3112,16 +4702,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 200;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = -700;
+        node_1.layout.top = 0;
+        node_1.layout.left = -700;
         node_1.layout.width = 900;
         node_1.layout.height = 0;
       }
@@ -3131,7 +4721,46 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase74()
+  public void testCase107()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.justifyContent = CSSJustify.FLEX_END;
+      node_0.style.width = 200;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 900;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 200;
+      node_0.layout.height = 0;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 900;
+        node_1.layout.height = 0;
+      }
+    }
+
+    test("should layout flex-end when remaining space is negative in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase108()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3159,24 +4788,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 200;
       node_0.layout.height = 58;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 58;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 20;
-          node_2.layout.x = 20;
+          node_2.layout.top = 20;
+          node_2.layout.left = 20;
           node_2.layout.width = 172.421875f;
           node_2.layout.height = 18;
         }
@@ -3187,7 +4816,64 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase75()
+  public void testCase109()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flexDirection = CSSFlexDirection.ROW;
+        node_1.style.width = 200;
+        addChildren(node_1, 1);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.margin[Spacing.LEFT] = 20;
+          node_2.style.margin[Spacing.TOP] = 20;
+          node_2.style.margin[Spacing.RIGHT] = 20;
+          node_2.style.margin[Spacing.BOTTOM] = 20;
+          node_2.setMeasureFunction(sTestMeasureFunction);
+          node_2.context = "loooooooooong with space";
+        }
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 200;
+      node_0.layout.height = 58;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 200;
+        node_1.layout.height = 58;
+        addChildren(node_1, 1);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 20;
+          node_2.layout.left = 7.578125f;
+          node_2.layout.width = 172.421875f;
+          node_2.layout.height = 18;
+        }
+      }
+    }
+
+    test("should layout text with flexDirection row in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase110()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3214,24 +4900,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 200;
       node_0.layout.height = 76;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 76;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 20;
-          node_2.layout.x = 20;
+          node_2.layout.top = 20;
+          node_2.layout.left = 20;
           node_2.layout.width = 160;
           node_2.layout.height = 36;
         }
@@ -3242,7 +4928,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase76()
+  public void testCase111()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3264,16 +4950,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 100;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 100;
       }
@@ -3283,7 +4969,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase77()
+  public void testCase112()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3306,21 +4992,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 25;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 25;
-        node_1.layout.x = 0;
+        node_1.layout.top = 25;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 75;
       }
@@ -3330,11 +5016,60 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase78()
+  public void testCase113()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
+      node_0.style.alignSelf = CSSAlign.FLEX_START;
+      node_0.style.width = 100;
+      node_0.style.height = 100;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.alignSelf = CSSAlign.FLEX_START;
+        node_1.style.flex = 2.5f;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.alignSelf = CSSAlign.FLEX_START;
+        node_1.style.flex = 7.5f;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 100;
+      node_0.layout.height = 100;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 75;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 25;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 0;
+        node_1.layout.height = 75;
+      }
+    }
+
+    test("should layout with arbitrary flex in reverse", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase114()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
       node_0.style.alignSelf = CSSAlign.FLEX_START;
       node_0.style.width = 100;
       node_0.style.height = 100;
@@ -3353,31 +5088,31 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
     }
 
-    test("should layout with negative flex", root_node, root_layout);
+    test("should layout with negative flex in reverse", root_node, root_layout);
   }
 
   @Test
-  public void testCase79()
+  public void testCase115()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3398,21 +5133,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 50;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 50;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 50;
         node_1.layout.height = 0;
       }
@@ -3422,7 +5157,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase80()
+  public void testCase116()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3441,16 +5176,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 80;
       }
@@ -3460,7 +5195,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase81()
+  public void testCase117()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3490,24 +5225,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 200;
       node_0.layout.height = 200;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 200;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 50;
-          node_2.layout.x = 0;
+          node_2.layout.top = 50;
+          node_2.layout.left = 0;
           node_2.layout.width = 100;
           node_2.layout.height = 100;
         }
@@ -3518,7 +5253,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase82()
+  public void testCase118()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3536,16 +5271,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 0;
+        node_1.layout.top = 100;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -3555,7 +5290,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase83()
+  public void testCase119()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3573,16 +5308,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 100;
+        node_1.layout.top = 0;
+        node_1.layout.left = 100;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -3592,7 +5327,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase84()
+  public void testCase120()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3611,16 +5346,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 90;
-        node_1.layout.x = 0;
+        node_1.layout.top = 90;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 10;
       }
@@ -3630,7 +5365,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase85()
+  public void testCase121()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3649,16 +5384,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 90;
+        node_1.layout.top = 0;
+        node_1.layout.left = 90;
         node_1.layout.width = 10;
         node_1.layout.height = 0;
       }
@@ -3668,7 +5403,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase86()
+  public void testCase122()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3686,16 +5421,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = -10;
-        node_1.layout.x = 0;
+        node_1.layout.top = -10;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 10;
       }
@@ -3705,7 +5440,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase87()
+  public void testCase123()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3723,16 +5458,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = -10;
+        node_1.layout.top = 0;
+        node_1.layout.left = -10;
         node_1.layout.width = 10;
         node_1.layout.height = 0;
       }
@@ -3742,7 +5477,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase88()
+  public void testCase124()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3759,16 +5494,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 1;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 1;
       }
@@ -3778,7 +5513,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase89()
+  public void testCase125()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3795,16 +5530,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = -3;
-        node_1.layout.x = 0;
+        node_1.layout.top = -3;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -3814,7 +5549,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase90()
+  public void testCase126()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3831,16 +5566,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 20;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 20;
-        node_1.layout.x = 0;
+        node_1.layout.top = 20;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -3850,7 +5585,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase91()
+  public void testCase127()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3867,16 +5602,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 5;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 0;
       }
@@ -3886,7 +5621,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase92()
+  public void testCase128()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3908,24 +5643,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 800;
       node_0.layout.height = 0;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 5;
+        node_1.layout.top = 0;
+        node_1.layout.left = 5;
         node_1.layout.width = 800;
         node_1.layout.height = 0;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 0;
-          node_2.layout.x = 0;
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
           node_2.layout.width = 800;
           node_2.layout.height = 0;
         }
@@ -3936,7 +5671,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase93()
+  public void testCase129()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -3962,26 +5697,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 20;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 40;
         node_1.layout.height = 10;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 40;
+        node_1.layout.top = 0;
+        node_1.layout.left = 40;
         node_1.layout.width = 40;
         node_1.layout.height = 10;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 10;
-        node_1.layout.x = 0;
+        node_1.layout.top = 10;
+        node_1.layout.left = 0;
         node_1.layout.width = 40;
         node_1.layout.height = 10;
       }
@@ -3991,7 +5726,63 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase94()
+  public void testCase130()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.flexWrap = CSSWrap.WRAP;
+      node_0.style.width = 100;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.width = 40;
+        node_1.style.height = 10;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.width = 40;
+        node_1.style.height = 10;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.width = 40;
+        node_1.style.height = 10;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 100;
+      node_0.layout.height = 20;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 60;
+        node_1.layout.width = 40;
+        node_1.layout.height = 10;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 20;
+        node_1.layout.width = 40;
+        node_1.layout.height = 10;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 10;
+        node_1.layout.left = 60;
+        node_1.layout.width = 40;
+        node_1.layout.height = 10;
+      }
+    }
+
+    test("should layout flex-wrap in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase131()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4011,21 +5802,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 0;
       node_0.layout.height = 100;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 100;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 0;
         node_1.layout.height = 200;
       }
@@ -4035,7 +5826,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase95()
+  public void testCase132()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4049,8 +5840,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 90;
       node_0.layout.height = 190;
     }
@@ -4059,7 +5850,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase96()
+  public void testCase133()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4073,8 +5864,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 110;
       node_0.layout.height = 210;
     }
@@ -4083,7 +5874,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase97()
+  public void testCase134()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4099,8 +5890,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 110;
       node_0.layout.height = 210;
     }
@@ -4109,7 +5900,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase98()
+  public void testCase135()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4125,8 +5916,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 90;
       node_0.layout.height = 190;
     }
@@ -4135,7 +5926,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase99()
+  public void testCase136()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4149,8 +5940,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 200;
     }
@@ -4159,7 +5950,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase100()
+  public void testCase137()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4173,8 +5964,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 200;
     }
@@ -4183,7 +5974,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase101()
+  public void testCase138()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4199,8 +5990,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 40;
       node_0.layout.height = 30;
     }
@@ -4209,7 +6000,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase102()
+  public void testCase139()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4225,8 +6016,8 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 50;
       node_0.layout.height = 40;
     }
@@ -4235,7 +6026,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase103()
+  public void testCase140()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4259,26 +6050,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 50;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 50;
+        node_1.layout.top = 0;
+        node_1.layout.left = 50;
         node_1.layout.width = 200;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 0;
-        node_1.layout.x = 250;
+        node_1.layout.top = 0;
+        node_1.layout.left = 250;
         node_1.layout.width = 50;
         node_1.layout.height = 200;
       }
@@ -4288,7 +6079,61 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase104()
+  public void testCase141()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 250;
+        node_1.layout.width = 50;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 50;
+        node_1.layout.width = 200;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 50;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should override flex direction size with min bounds in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase142()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4313,26 +6158,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 100;
+        node_1.layout.top = 0;
+        node_1.layout.left = 100;
         node_1.layout.width = 100;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 0;
-        node_1.layout.x = 200;
+        node_1.layout.top = 0;
+        node_1.layout.left = 200;
         node_1.layout.width = 100;
         node_1.layout.height = 200;
       }
@@ -4342,7 +6187,62 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase105()
+  public void testCase143()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 110;
+        node_1.style.minWidth = 90;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 200;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 100;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 100;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should not override flex direction size within bounds in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase144()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4366,26 +6266,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 120;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 120;
+        node_1.layout.top = 0;
+        node_1.layout.left = 120;
         node_1.layout.width = 60;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 0;
-        node_1.layout.x = 180;
+        node_1.layout.top = 0;
+        node_1.layout.left = 180;
         node_1.layout.width = 120;
         node_1.layout.height = 200;
       }
@@ -4395,7 +6295,61 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase106()
+  public void testCase145()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 180;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 120;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should override flex direction size with max bounds in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase146()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4421,26 +6375,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 60;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 60;
+        node_1.layout.top = 0;
+        node_1.layout.left = 60;
         node_1.layout.width = 60;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 0;
-        node_1.layout.x = 120;
+        node_1.layout.top = 0;
+        node_1.layout.left = 120;
         node_1.layout.width = 60;
         node_1.layout.height = 200;
       }
@@ -4450,7 +6404,63 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase107()
+  public void testCase147()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+        node_1.style.maxWidth = 60;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 240;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 180;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 0;
+        node_1.layout.left = 120;
+        node_1.layout.width = 60;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should ignore flex size if fully max bound in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase148()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4476,26 +6486,26 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 120;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 0;
-        node_1.layout.x = 120;
+        node_1.layout.top = 0;
+        node_1.layout.left = 120;
         node_1.layout.width = 120;
         node_1.layout.height = 200;
         node_1 = node_0.getChildAt(2);
-        node_1.layout.y = 0;
-        node_1.layout.x = 240;
+        node_1.layout.top = 0;
+        node_1.layout.left = 240;
         node_1.layout.width = 120;
         node_1.layout.height = 200;
       }
@@ -4505,7 +6515,63 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase108()
+  public void testCase149()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 300;
+      node_0.style.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 120;
+        node_1 = node_0.getChildAt(1);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 120;
+        node_1 = node_0.getChildAt(2);
+        node_1.style.flex = 1;
+        node_1.style.minWidth = 120;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 300;
+      node_0.layout.height = 200;
+      addChildren(node_0, 3);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 180;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 0;
+        node_1.layout.left = 60;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+        node_1 = node_0.getChildAt(2);
+        node_1.layout.top = 0;
+        node_1.layout.left = -60;
+        node_1.layout.width = 120;
+        node_1.layout.height = 200;
+      }
+    }
+
+    test("should ignore flex size if fully min bound in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase150()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4525,16 +6591,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 300;
         node_1.layout.height = 200;
       }
@@ -4544,7 +6610,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase109()
+  public void testCase151()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4563,16 +6629,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 290;
         node_1.layout.height = 200;
       }
@@ -4582,7 +6648,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase110()
+  public void testCase152()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4601,16 +6667,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 200;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 310;
         node_1.layout.height = 200;
       }
@@ -4620,7 +6686,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase111()
+  public void testCase153()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4644,21 +6710,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 200;
       node_0.layout.height = 600;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 300;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 300;
-        node_1.layout.x = 0;
+        node_1.layout.top = 300;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 300;
       }
@@ -4668,7 +6734,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase112()
+  public void testCase154()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4690,21 +6756,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 100;
       node_0.layout.height = 500;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 300;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 300;
-        node_1.layout.x = 0;
+        node_1.layout.top = 300;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 300;
       }
@@ -4714,7 +6780,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase113()
+  public void testCase155()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4736,21 +6802,21 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 300;
       node_0.layout.height = 700;
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 300;
         node_1 = node_0.getChildAt(1);
-        node_1.layout.y = 300;
-        node_1.layout.x = 0;
+        node_1.layout.top = 300;
+        node_1.layout.left = 0;
         node_1.layout.width = 200;
         node_1.layout.height = 300;
       }
@@ -4760,7 +6826,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase114()
+  public void testCase156()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4782,16 +6848,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 100;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 1000;
         node_1.layout.height = 100;
       }
@@ -4801,7 +6867,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase115()
+  public void testCase157()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4821,16 +6887,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 90;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 900;
         node_1.layout.height = 90;
       }
@@ -4840,7 +6906,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase116()
+  public void testCase158()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4860,16 +6926,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 110;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 1100;
         node_1.layout.height = 110;
       }
@@ -4879,7 +6945,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase117()
+  public void testCase159()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4899,16 +6965,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 110;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 100;
         node_1.layout.height = 110;
       }
@@ -4918,7 +6984,47 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase118()
+  public void testCase160()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.flexDirection = CSSFlexDirection.ROW;
+      node_0.style.width = 1000;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.height = 100;
+        node_1.style.minWidth = 100;
+        node_1.style.minHeight = 110;
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 1000;
+      node_0.layout.height = 110;
+      addChildren(node_0, 1);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 900;
+        node_1.layout.width = 100;
+        node_1.layout.height = 110;
+      }
+    }
+
+    test("should keep cross axis size within min bounds in rtl", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase161()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4942,16 +7048,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 100;
+        node_1.layout.top = 100;
+        node_1.layout.left = 100;
         node_1.layout.width = 500;
         node_1.layout.height = 600;
       }
@@ -4961,7 +7067,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase119()
+  public void testCase162()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -4985,16 +7091,16 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 1000;
       node_0.layout.height = 1000;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 100;
+        node_1.layout.top = 100;
+        node_1.layout.left = 100;
         node_1.layout.width = 900;
         node_1.layout.height = 1000;
       }
@@ -5004,7 +7110,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase120()
+  public void testCase163()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -5040,24 +7146,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 400;
       node_0.layout.height = 400;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 100;
+        node_1.layout.top = 100;
+        node_1.layout.left = 100;
         node_1.layout.width = 200;
         node_1.layout.height = 200;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 10;
-          node_2.layout.x = 10;
+          node_2.layout.top = 10;
+          node_2.layout.left = 10;
           node_2.layout.width = 180;
           node_2.layout.height = 180;
         }
@@ -5068,7 +7174,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase121()
+  public void testCase164()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -5108,24 +7214,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 400;
       node_0.layout.height = 400;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 100;
-        node_1.layout.x = 100;
+        node_1.layout.top = 100;
+        node_1.layout.left = 100;
         node_1.layout.width = 200;
         node_1.layout.height = 200;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 11;
-          node_2.layout.x = 11;
+          node_2.layout.top = 11;
+          node_2.layout.left = 11;
           node_2.layout.width = 178;
           node_2.layout.height = 178;
         }
@@ -5136,7 +7242,7 @@ public class LayoutEngineTest {
   }
 
   @Test
-  public void testCase122()
+  public void testCase165()
   {
     TestCSSNode root_node = new TestCSSNode();
     {
@@ -5168,24 +7274,24 @@ public class LayoutEngineTest {
     TestCSSNode root_layout = new TestCSSNode();
     {
       TestCSSNode node_0 = root_layout;
-      node_0.layout.y = 0;
-      node_0.layout.x = 0;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
       node_0.layout.width = 400;
       node_0.layout.height = 400;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.layout.y = 0;
-        node_1.layout.x = 0;
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
         node_1.layout.width = 400;
         node_1.layout.height = 400;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.layout.y = 10;
-          node_2.layout.x = 10;
+          node_2.layout.top = 10;
+          node_2.layout.left = 10;
           node_2.layout.width = 380;
           node_2.layout.height = 380;
         }
@@ -5193,6 +7299,100 @@ public class LayoutEngineTest {
     }
 
     test("should layout absolutely positioned node with padded flex 1 parent", root_node, root_layout);
+  }
+
+  @Test
+  public void testCase166()
+  {
+    TestCSSNode root_node = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_node;
+      node_0.style.direction = CSSDirection.RTL;
+      node_0.style.width = 200;
+      node_0.style.height = 200;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.style.flexDirection = CSSFlexDirection.ROW;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.width = 50;
+          node_2.style.height = 50;
+          node_2 = node_1.getChildAt(1);
+          node_2.style.width = 50;
+          node_2.style.height = 50;
+        }
+        node_1 = node_0.getChildAt(1);
+        node_1.style.direction = CSSDirection.LTR;
+        node_1.style.flexDirection = CSSFlexDirection.ROW;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.style.width = 50;
+          node_2.style.height = 50;
+          node_2 = node_1.getChildAt(1);
+          node_2.style.width = 50;
+          node_2.style.height = 50;
+        }
+      }
+    }
+
+    TestCSSNode root_layout = new TestCSSNode();
+    {
+      TestCSSNode node_0 = root_layout;
+      node_0.layout.top = 0;
+      node_0.layout.left = 0;
+      node_0.layout.width = 200;
+      node_0.layout.height = 200;
+      addChildren(node_0, 2);
+      {
+        TestCSSNode node_1;
+        node_1 = node_0.getChildAt(0);
+        node_1.layout.top = 0;
+        node_1.layout.left = 0;
+        node_1.layout.width = 200;
+        node_1.layout.height = 50;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 0;
+          node_2.layout.left = 150;
+          node_2.layout.width = 50;
+          node_2.layout.height = 50;
+          node_2 = node_1.getChildAt(1);
+          node_2.layout.top = 0;
+          node_2.layout.left = 100;
+          node_2.layout.width = 50;
+          node_2.layout.height = 50;
+        }
+        node_1 = node_0.getChildAt(1);
+        node_1.layout.top = 50;
+        node_1.layout.left = 0;
+        node_1.layout.width = 200;
+        node_1.layout.height = 50;
+        addChildren(node_1, 2);
+        {
+          TestCSSNode node_2;
+          node_2 = node_1.getChildAt(0);
+          node_2.layout.top = 0;
+          node_2.layout.left = 0;
+          node_2.layout.width = 50;
+          node_2.layout.height = 50;
+          node_2 = node_1.getChildAt(1);
+          node_2.layout.top = 0;
+          node_2.layout.left = 50;
+          node_2.layout.width = 50;
+          node_2.layout.height = 50;
+        }
+      }
+    }
+
+    test("should layout nested nodes with mixed directions", root_node, root_layout);
   }
   /** END_GENERATED **/
 }

--- a/src/transpile.js
+++ b/src/transpile.js
@@ -111,9 +111,15 @@ function printLayout(test) {
       }
     }
 
+    addEnum(node, 'direction', 'direction', {
+      'ltr': 'CSS_DIRECTION_LTR',
+      'rtl': 'CSS_DIRECTION_RTL'
+    });
     addEnum(node, 'flexDirection', 'flex_direction', {
       'row': 'CSS_FLEX_DIRECTION_ROW',
-      'column': 'CSS_FLEX_DIRECTION_COLUMN'
+      'row-reverse': 'CSS_FLEX_DIRECTION_ROW_REVERSE',
+      'column': 'CSS_FLEX_DIRECTION_COLUMN',
+      'column-reverse': 'CSS_FLEX_DIRECTION_COLUMN_REVERSE'
     });
     addEnum(node, 'justifyContent', 'justify_content', {
       'flex-start': 'CSS_JUSTIFY_FLEX_START',
@@ -234,6 +240,7 @@ function transpileAnnotatedJStoC(jsCode) {
     .replace(/layout\[dim/g, 'layout.dimensions[dim')
     .replace(/layout\[pos/g, 'layout.position[pos')
     .replace(/layout\[leading/g, 'layout.position[leading')
+    .replace(/layout\[trailing/g, 'layout.position[trailing')
     .replace(/style\[dim/g, 'style.dimensions[dim')
     .replace(/node.children\[i\]/g, 'node->get_child(node->context, i)')
     .replace(/node\./g, 'node->')


### PR DESCRIPTION
This PR adds support for a direction style property (equivalent to Chrome's `direction` CSS property) that allows you to change the row flow for flexbox allows. By default, all nodes inherit the direction from their parents. If the parent direction is not explicitly defined, left-to-right is used. This means that, by default, nodes from a subtree will share the same direction defined by the root. You can also have node trees with mixed directions, as covered by one of the new tests.

Given that the work to implement RTL support is analogous to `ROW_REVERSE` and `COLUMN_REVERSE`, I went ahead and implemented them as well.

These new features require a small API break in the `layoutNode()` for both C and Java as well as a few new types for the new direction style property and the new flex direction values.

I added a bunch of analogous tests for the reversed layout cases and a few new tests to verify that the new features work correctly.

I split the changes into separate commits to make them a bit easier to review: one with the Javascript changes and another with the updates to the transpiled versions. I'll squash them together before merging. 