### PR TITLE
[java] implement proper spacing objects, with support for default spacing

### DIFF
--- a/src/JavaTranspiler.js
+++ b/src/JavaTranspiler.js
@@ -76,10 +76,16 @@ function __transpileSingleTestToJava(code) {
         function (str, match1, match2) {
             return 'style.' + match1 + match2[0] + match2.substring(1).toLowerCase();
         })
-    .replace( // style.margin[CSS_TOP] => style.margin[Spacing.TOP]
+    .replace( // style.margin[CSS_TOP] = 12.3 => style.margin[Spacing.TOP].set(12.3)
+        /style\.(margin|border|padding)\[CSS_(TOP|BOTTOM|LEFT|RIGHT)\]\s+=\s+(-?[\.\d]+)/g,
+        function (str, match1, match2, match3) {
+          var propertyCap = match1.charAt(0).toUpperCase() + match1.slice(1);
+          return 'set' + propertyCap + '(Spacing.' + match2 + ', ' + match3 + ')';
+        })
+    .replace( // style.margin[CSS_TOP] => style.margin.get(Spacing.TOP)
         /style\.(margin|border|padding)\[CSS_(TOP|BOTTOM|LEFT|RIGHT)\]/g,
         function (str, match1, match2) {
-          return 'style.' + match1 + '[Spacing.' + match2 + ']';
+          return 'style.' + match1 + '.get(Spacing.' + match2 + ')';
         })
     .replace(/get_child\(.*context\,\s([^\)]+)\)/g, 'getChildAt($1)')
     .replace(/init_css_node_children/g, 'addChildren')

--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -49,10 +49,6 @@ public class CSSNode {
     public void measure(CSSNode node, float width, MeasureOutput measureOutput);
   }
 
-  private final float[] mMargin = Spacing.newFullSpacingArray();
-  private final float[] mPadding = Spacing.newFullSpacingArray();
-  private final float[] mBorder = Spacing.newFullSpacingArray();
-
   // VisibleForTesting
   /*package*/ final CSSStyle style = new CSSStyle();
   /*package*/ final CSSLayout layout = new CSSLayout();
@@ -263,24 +259,19 @@ public class CSSNode {
   }
 
   public void setMargin(int spacingType, float margin) {
-    setSpacing(mMargin, style.margin, spacingType, margin);
+    if (style.margin.set(spacingType, margin)) {
+      dirty();
+    }
   }
 
   public void setPadding(int spacingType, float padding) {
-    setSpacing(mPadding, style.padding, spacingType, padding);
+    if (style.padding.set(spacingType, padding)) {
+      dirty();
+    }
   }
 
   public void setBorder(int spacingType, float border) {
-    setSpacing(mBorder, style.border, spacingType, border);
-  }
-
-  protected void setSpacing(
-       float[] spacingDef,
-       float[] cssStyle,
-       int spacingType,
-       float spacing) {
-    if (!valuesEqual(spacingDef[spacingType], spacing)) {
-      Spacing.updateSpacing(spacingDef, cssStyle, spacingType, spacing, 0);
+    if (style.border.set(spacingType, border)) {
       dirty();
     }
   }
@@ -341,5 +332,21 @@ public class CSSNode {
 
   public float getLayoutHeight() {
     return layout.height;
+  }
+
+  /**
+   * Get this node's padding, as defined by style + default padding.
+   */
+  public Spacing getStylePadding() {
+    return style.padding;
+  }
+
+  /**
+   * Set a default padding (left/top/right/bottom) for this node.
+   */
+  public void setDefaultPadding(int spacingType, float padding) {
+    if (style.padding.setDefault(spacingType, padding)) {
+      dirty();
+    }
   }
 }

--- a/src/java/src/com/facebook/csslayout/CSSStyle.java
+++ b/src/java/src/com/facebook/csslayout/CSSStyle.java
@@ -22,9 +22,9 @@ public class CSSStyle {
   public CSSWrap flexWrap = CSSWrap.NOWRAP;
   public float flex;
 
-  public float[] margin = Spacing.newSpacingResultArray();
-  public float[] padding = Spacing.newSpacingResultArray();
-  public float[] border = Spacing.newSpacingResultArray();
+  public Spacing margin = new Spacing();
+  public Spacing padding = new Spacing();
+  public Spacing border = new Spacing();
 
   public float positionTop = CSSConstants.UNDEFINED;
   public float positionBottom = CSSConstants.UNDEFINED;

--- a/src/java/src/com/facebook/csslayout/LayoutEngine.java
+++ b/src/java/src/com/facebook/csslayout/LayoutEngine.java
@@ -184,13 +184,13 @@ public class LayoutEngine {
   private static float getMargin(CSSNode node, PositionIndex position) {
     switch (position) {
       case TOP:
-        return node.style.margin[Spacing.TOP];
+        return node.style.margin.get(Spacing.TOP);
       case BOTTOM:
-        return node.style.margin[Spacing.BOTTOM];
+        return node.style.margin.get(Spacing.BOTTOM);
       case LEFT:
-        return node.style.margin[Spacing.LEFT];
+        return node.style.margin.get(Spacing.LEFT);
       case RIGHT:
-        return node.style.margin[Spacing.RIGHT];
+        return node.style.margin.get(Spacing.RIGHT);
       default:
         throw new RuntimeException("Someone added a new cardinal direction...");
     }
@@ -199,13 +199,13 @@ public class LayoutEngine {
   private static float getPadding(CSSNode node, PositionIndex position) {
     switch (position) {
       case TOP:
-        return node.style.padding[Spacing.TOP];
+        return node.style.padding.get(Spacing.TOP);
       case BOTTOM:
-        return node.style.padding[Spacing.BOTTOM];
+        return node.style.padding.get(Spacing.BOTTOM);
       case LEFT:
-        return node.style.padding[Spacing.LEFT];
+        return node.style.padding.get(Spacing.LEFT);
       case RIGHT:
-        return node.style.padding[Spacing.RIGHT];
+        return node.style.padding.get(Spacing.RIGHT);
       default:
         throw new RuntimeException("Someone added a new cardinal direction...");
     }
@@ -214,13 +214,13 @@ public class LayoutEngine {
   private static float getBorder(CSSNode node, PositionIndex position) {
     switch (position) {
       case TOP:
-        return node.style.border[Spacing.TOP];
+        return node.style.border.get(Spacing.TOP);
       case BOTTOM:
-        return node.style.border[Spacing.BOTTOM];
+        return node.style.border.get(Spacing.BOTTOM);
       case LEFT:
-        return node.style.border[Spacing.LEFT];
+        return node.style.border.get(Spacing.LEFT);
       case RIGHT:
-        return node.style.border[Spacing.RIGHT];
+        return node.style.border.get(Spacing.RIGHT);
       default:
         throw new RuntimeException("Someone added a new cardinal direction...");
     }

--- a/src/java/src/com/facebook/csslayout/Spacing.java
+++ b/src/java/src/com/facebook/csslayout/Spacing.java
@@ -9,27 +9,102 @@
 package com.facebook.csslayout;
 
 /**
- * Utility class for handling CSS spacing (padding, margin, and borders). This is mostly necessary
- * to properly implement interactions and updates for properties like margin, marginLeft, and
- * marginHorizontal. This is not a great API and should probably be updated to use actual objects
- * for type safety, defaults safety, and simplicity.
+ * Class representing CSS spacing (padding, margin, and borders). This is mostly necessary to
+ * properly implement interactions and updates for properties like margin, marginLeft, and
+ * marginHorizontal.
  */
 public class Spacing {
 
-  // Indices into FullSpacingArray and SpacingResultArray
+  /**
+   * Spacing type that represents the left direction. E.g. {@code marginLeft}.
+   */
   public static final int LEFT = 0;
+  /**
+   * Spacing type that represents the top direction. E.g. {@code marginTop}.
+   */
   public static final int TOP = 1;
+  /**
+   * Spacing type that represents the right direction. E.g. {@code marginRight}.
+   */
   public static final int RIGHT = 2;
+  /**
+   * Spacing type that represents the bottom direction. E.g. {@code marginBottom}.
+   */
   public static final int BOTTOM = 3;
+  /**
+   * Spacing type that represents vertical direction (top and bottom). E.g. {@code marginVertical}.
+   */
   public static final int VERTICAL = 4;
+  /**
+   * Spacing type that represents horizontal direction (left and right). E.g.
+   * {@code marginHorizontal}.
+   */
   public static final int HORIZONTAL = 5;
+  /**
+   * Spacing type that represents all directions (left, top, right, bottom). E.g. {@code margin}.
+   */
   public static final int ALL = 6;
 
+  private final float[] mSpacing = newFullSpacingArray();
+  private final float[] mDefaultSpacing = newSpacingResultArray();
+  private final float[] mSpacingResult = newSpacingResultArray();
+  private boolean mDirty;
+
   /**
-   * @return an instance of an array that can be used with {@link #updateSpacing}. Stores
-   * the value for each spacing type or NaN if it hasn't been explicitly set.
+   * Set a spacing value.
+   *
+   * @param spacingType one of {@link #LEFT}, {@link #TOP}, {@link #RIGHT}, {@link #BOTTOM},
+   *        {@link #VERTICAL}, {@link #HORIZONTAL}, {@link #ALL}
+   * @param value the value for this direction
+   * @return {@code true} if the spacing has changed, or {@code false} if the same value was already
+   *         set
    */
-  public static float[] newFullSpacingArray() {
+  public boolean set(int spacingType, float value) {
+    if (!FloatUtil.floatsEqual(mSpacing[spacingType], value)) {
+      mSpacing[spacingType] = value;
+      mDirty = true;
+    }
+    return mDirty;
+  }
+
+  /**
+   * Set a default spacing value. This is used as a fallback when no spacing has been set for a
+   * particular direction.
+   *
+   * @param spacingType one of {@link #LEFT}, {@link #TOP}, {@link #RIGHT}, {@link #BOTTOM}
+   * @param value the default value for this direction
+   * @return
+   */
+  public boolean setDefault(int spacingType, float value) {
+    if (!FloatUtil.floatsEqual(mDefaultSpacing[spacingType], value)) {
+      mDefaultSpacing[spacingType] = value;
+      mDirty = true;
+    }
+    return mDirty;
+  }
+
+  /**
+   * Get the spacing for a direction. This takes into account any default values that have been set.
+   *
+   * @param spacingType one of {@link #LEFT}, {@link #TOP}, {@link #RIGHT}, {@link #BOTTOM}
+   */
+  public float get(int spacingType) {
+    ensureResult();
+    return mSpacingResult[spacingType];
+  }
+
+  /**
+   * Get the raw value (that was set using {@link #set(int, float)}), without taking into account
+   * any default values.
+   *
+   * @param spacingType one of {@link #LEFT}, {@link #TOP}, {@link #RIGHT}, {@link #BOTTOM},
+   *        {@link #VERTICAL}, {@link #HORIZONTAL}, {@link #ALL}
+   */
+  public float getRaw(int spacingType) {
+    return mSpacing[spacingType];
+  }
+
+  private static float[] newFullSpacingArray() {
     return new float[] {
         CSSConstants.UNDEFINED,
         CSSConstants.UNDEFINED,
@@ -42,18 +117,11 @@ public class Spacing {
     };
   }
 
-  /**
-   * @return {@link #newSpacingResultArray} filled with zero.
-   */
-  public static float[] newSpacingResultArray() {
+  private static float[] newSpacingResultArray() {
     return newSpacingResultArray(0);
   }
 
-  /**
-   * @return an instance of an array used to store the end result of the interactions between the
-   * values in a full spacing array. Use {@link #TOP}, etc to access result values.
-   */
-  public static float[] newSpacingResultArray(float defaultValue) {
+  private static float[] newSpacingResultArray(float defaultValue) {
     return new float[] {
         defaultValue,
         defaultValue,
@@ -63,41 +131,46 @@ public class Spacing {
   }
 
   /**
-   * Given the fullSpacing from {@link #newFullSpacingArray()} and the spacingResult from
-   * {@link #newSpacingResultArray()} from a View, update them both to reflect a new value for the
-   * given spacingType (e.g. {@link #TOP}). defaultValue specifies the result value that should be
-   * used whenever a spacing property hasn't been set.
+   * Given the {@param fullSpacing} and the spacingResult from {@link #newSpacingResultArray()} from
+   * a View, update the result array to reflect values that have been set in {@param fullSpacing}
+   * array. {@param defaultValues} specifies the result values that should be used whenever a
+   * spacing property hasn't been set.
    */
-  public static void updateSpacing(
-      float[] fullSpacing,
-      float[] spacingResult,
-      int spacingType,
-      float value,
-      float defaultValue) {
-    fullSpacing[spacingType] = value;
-    spacingResult[Spacing.TOP] =
-        !CSSConstants.isUndefined(fullSpacing[Spacing.TOP]) ? fullSpacing[Spacing.TOP]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.VERTICAL]) ?
-                fullSpacing[Spacing.VERTICAL]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.ALL]) ? fullSpacing[Spacing.ALL]
-            : defaultValue;
-    spacingResult[Spacing.BOTTOM] =
-        !CSSConstants.isUndefined(fullSpacing[Spacing.BOTTOM]) ? fullSpacing[Spacing.BOTTOM]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.VERTICAL]) ?
-                fullSpacing[Spacing.VERTICAL]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.ALL]) ? fullSpacing[Spacing.ALL]
-            : defaultValue;
-    spacingResult[Spacing.LEFT] =
-        !CSSConstants.isUndefined(fullSpacing[Spacing.LEFT]) ? fullSpacing[Spacing.LEFT]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.HORIZONTAL]) ?
-                fullSpacing[Spacing.HORIZONTAL]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.ALL]) ? fullSpacing[Spacing.ALL]
-            : defaultValue;
-    spacingResult[Spacing.RIGHT] =
-        !CSSConstants.isUndefined(fullSpacing[Spacing.RIGHT]) ? fullSpacing[Spacing.RIGHT]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.HORIZONTAL]) ?
-                fullSpacing[Spacing.HORIZONTAL]
-            : !CSSConstants.isUndefined(fullSpacing[Spacing.ALL]) ? fullSpacing[Spacing.ALL]
-            : defaultValue;
+  private void ensureResult() {
+    if (mDirty) {
+      mSpacingResult[TOP] =
+          !CSSConstants.isUndefined(mSpacing[TOP])
+              ? mSpacing[TOP]
+              : !CSSConstants.isUndefined(mSpacing[VERTICAL])
+                ? mSpacing[VERTICAL]
+                : !CSSConstants.isUndefined(mSpacing[ALL])
+                  ? mSpacing[ALL]
+                  : mDefaultSpacing[TOP];
+      mSpacingResult[BOTTOM] =
+          !CSSConstants.isUndefined(mSpacing[BOTTOM])
+              ? mSpacing[BOTTOM]
+              : !CSSConstants.isUndefined(mSpacing[VERTICAL])
+                ? mSpacing[VERTICAL]
+                : !CSSConstants.isUndefined(mSpacing[ALL])
+                  ? mSpacing[ALL]
+                  : mDefaultSpacing[BOTTOM];
+      mSpacingResult[LEFT] =
+          !CSSConstants.isUndefined(mSpacing[LEFT])
+              ? mSpacing[LEFT]
+              : !CSSConstants.isUndefined(mSpacing[HORIZONTAL])
+                ? mSpacing[HORIZONTAL]
+                : !CSSConstants.isUndefined(mSpacing[ALL])
+                  ? mSpacing[ALL]
+                  : mDefaultSpacing[LEFT];
+      mSpacingResult[RIGHT] =
+          !CSSConstants.isUndefined(mSpacing[RIGHT])
+              ? mSpacing[RIGHT]
+              : !CSSConstants.isUndefined(mSpacing[HORIZONTAL])
+                ? mSpacing[HORIZONTAL]
+                : !CSSConstants.isUndefined(mSpacing[ALL])
+                  ? mSpacing[ALL]
+                  : mDefaultSpacing[RIGHT];
+      mDirty = false;
+    }
   }
 }

--- a/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
+++ b/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
@@ -370,10 +370,10 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.width = 100;
       node_0.style.height = 200;
-      node_0.style.margin[Spacing.LEFT] = 10;
-      node_0.style.margin[Spacing.TOP] = 10;
-      node_0.style.margin[Spacing.RIGHT] = 10;
-      node_0.style.margin[Spacing.BOTTOM] = 10;
+      node_0.setMargin(Spacing.LEFT, 10);
+      node_0.setMargin(Spacing.TOP, 10);
+      node_0.setMargin(Spacing.RIGHT, 10);
+      node_0.setMargin(Spacing.BOTTOM, 10);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -396,34 +396,34 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.width = 1000;
       node_0.style.height = 1000;
-      node_0.style.margin[Spacing.LEFT] = 10;
-      node_0.style.margin[Spacing.TOP] = 10;
-      node_0.style.margin[Spacing.RIGHT] = 10;
-      node_0.style.margin[Spacing.BOTTOM] = 10;
+      node_0.setMargin(Spacing.LEFT, 10);
+      node_0.setMargin(Spacing.TOP, 10);
+      node_0.setMargin(Spacing.RIGHT, 10);
+      node_0.setMargin(Spacing.BOTTOM, 10);
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 50;
-        node_1.style.margin[Spacing.TOP] = 50;
-        node_1.style.margin[Spacing.RIGHT] = 50;
-        node_1.style.margin[Spacing.BOTTOM] = 50;
+        node_1.setMargin(Spacing.LEFT, 50);
+        node_1.setMargin(Spacing.TOP, 50);
+        node_1.setMargin(Spacing.RIGHT, 50);
+        node_1.setMargin(Spacing.BOTTOM, 50);
         node_1 = node_0.getChildAt(1);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 25;
-        node_1.style.margin[Spacing.TOP] = 25;
-        node_1.style.margin[Spacing.RIGHT] = 25;
-        node_1.style.margin[Spacing.BOTTOM] = 25;
+        node_1.setMargin(Spacing.LEFT, 25);
+        node_1.setMargin(Spacing.TOP, 25);
+        node_1.setMargin(Spacing.RIGHT, 25);
+        node_1.setMargin(Spacing.BOTTOM, 25);
         node_1 = node_0.getChildAt(2);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 10;
-        node_1.style.margin[Spacing.TOP] = 10;
-        node_1.style.margin[Spacing.RIGHT] = 10;
-        node_1.style.margin[Spacing.BOTTOM] = 10;
+        node_1.setMargin(Spacing.LEFT, 10);
+        node_1.setMargin(Spacing.TOP, 10);
+        node_1.setMargin(Spacing.RIGHT, 10);
+        node_1.setMargin(Spacing.BOTTOM, 10);
       }
     }
 
@@ -467,34 +467,34 @@ public class LayoutEngineTest {
       node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
       node_0.style.width = 1000;
       node_0.style.height = 1000;
-      node_0.style.margin[Spacing.LEFT] = 10;
-      node_0.style.margin[Spacing.TOP] = 10;
-      node_0.style.margin[Spacing.RIGHT] = 10;
-      node_0.style.margin[Spacing.BOTTOM] = 10;
+      node_0.setMargin(Spacing.LEFT, 10);
+      node_0.setMargin(Spacing.TOP, 10);
+      node_0.setMargin(Spacing.RIGHT, 10);
+      node_0.setMargin(Spacing.BOTTOM, 10);
       addChildren(node_0, 3);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 50;
-        node_1.style.margin[Spacing.TOP] = 50;
-        node_1.style.margin[Spacing.RIGHT] = 50;
-        node_1.style.margin[Spacing.BOTTOM] = 50;
+        node_1.setMargin(Spacing.LEFT, 50);
+        node_1.setMargin(Spacing.TOP, 50);
+        node_1.setMargin(Spacing.RIGHT, 50);
+        node_1.setMargin(Spacing.BOTTOM, 50);
         node_1 = node_0.getChildAt(1);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 25;
-        node_1.style.margin[Spacing.TOP] = 25;
-        node_1.style.margin[Spacing.RIGHT] = 25;
-        node_1.style.margin[Spacing.BOTTOM] = 25;
+        node_1.setMargin(Spacing.LEFT, 25);
+        node_1.setMargin(Spacing.TOP, 25);
+        node_1.setMargin(Spacing.RIGHT, 25);
+        node_1.setMargin(Spacing.BOTTOM, 25);
         node_1 = node_0.getChildAt(2);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 10;
-        node_1.style.margin[Spacing.TOP] = 10;
-        node_1.style.margin[Spacing.RIGHT] = 10;
-        node_1.style.margin[Spacing.BOTTOM] = 10;
+        node_1.setMargin(Spacing.LEFT, 10);
+        node_1.setMargin(Spacing.TOP, 10);
+        node_1.setMargin(Spacing.RIGHT, 10);
+        node_1.setMargin(Spacing.BOTTOM, 10);
       }
     }
 
@@ -1008,21 +1008,21 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.width = 1000;
       node_0.style.height = 1000;
-      node_0.style.margin[Spacing.LEFT] = 5;
-      node_0.style.margin[Spacing.TOP] = 10;
+      node_0.setMargin(Spacing.LEFT, 5);
+      node_0.setMargin(Spacing.TOP, 10);
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 15;
-        node_1.style.margin[Spacing.TOP] = 50;
-        node_1.style.margin[Spacing.BOTTOM] = 20;
+        node_1.setMargin(Spacing.LEFT, 15);
+        node_1.setMargin(Spacing.TOP, 50);
+        node_1.setMargin(Spacing.BOTTOM, 20);
         node_1 = node_0.getChildAt(1);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 30;
+        node_1.setMargin(Spacing.LEFT, 30);
       }
     }
 
@@ -1061,21 +1061,21 @@ public class LayoutEngineTest {
       node_0.style.flexDirection = CSSFlexDirection.COLUMN_REVERSE;
       node_0.style.width = 1000;
       node_0.style.height = 1000;
-      node_0.style.margin[Spacing.LEFT] = 5;
-      node_0.style.margin[Spacing.TOP] = 10;
+      node_0.setMargin(Spacing.LEFT, 5);
+      node_0.setMargin(Spacing.TOP, 10);
       addChildren(node_0, 2);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 15;
-        node_1.style.margin[Spacing.TOP] = 50;
-        node_1.style.margin[Spacing.BOTTOM] = 20;
+        node_1.setMargin(Spacing.LEFT, 15);
+        node_1.setMargin(Spacing.TOP, 50);
+        node_1.setMargin(Spacing.BOTTOM, 20);
         node_1 = node_0.getChildAt(1);
         node_1.style.width = 100;
         node_1.style.height = 100;
-        node_1.style.margin[Spacing.LEFT] = 30;
+        node_1.setMargin(Spacing.LEFT, 30);
       }
     }
 
@@ -2157,10 +2157,10 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.LEFT] = 5;
-        node_1.style.margin[Spacing.TOP] = 5;
-        node_1.style.margin[Spacing.RIGHT] = 5;
-        node_1.style.margin[Spacing.BOTTOM] = 5;
+        node_1.setMargin(Spacing.LEFT, 5);
+        node_1.setMargin(Spacing.TOP, 5);
+        node_1.setMargin(Spacing.RIGHT, 5);
+        node_1.setMargin(Spacing.BOTTOM, 5);
       }
     }
 
@@ -2196,10 +2196,10 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.LEFT] = 5;
-        node_1.style.margin[Spacing.TOP] = 5;
-        node_1.style.margin[Spacing.RIGHT] = 5;
-        node_1.style.margin[Spacing.BOTTOM] = 5;
+        node_1.setMargin(Spacing.LEFT, 5);
+        node_1.setMargin(Spacing.TOP, 5);
+        node_1.setMargin(Spacing.RIGHT, 5);
+        node_1.setMargin(Spacing.BOTTOM, 5);
       }
     }
 
@@ -2344,7 +2344,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.TOP] = 10;
+        node_1.setMargin(Spacing.TOP, 10);
       }
     }
 
@@ -2382,7 +2382,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.TOP] = 10;
+        node_1.setMargin(Spacing.TOP, 10);
       }
     }
 
@@ -2422,10 +2422,10 @@ public class LayoutEngineTest {
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.style.margin[Spacing.LEFT] = 10;
-          node_2.style.margin[Spacing.TOP] = 10;
-          node_2.style.margin[Spacing.RIGHT] = 10;
-          node_2.style.margin[Spacing.BOTTOM] = 10;
+          node_2.setMargin(Spacing.LEFT, 10);
+          node_2.setMargin(Spacing.TOP, 10);
+          node_2.setMargin(Spacing.RIGHT, 10);
+          node_2.setMargin(Spacing.BOTTOM, 10);
           node_2 = node_1.getChildAt(1);
           node_2.style.height = 100;
         }
@@ -2483,10 +2483,10 @@ public class LayoutEngineTest {
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.style.margin[Spacing.LEFT] = 10;
-          node_2.style.margin[Spacing.TOP] = 10;
-          node_2.style.margin[Spacing.RIGHT] = 10;
-          node_2.style.margin[Spacing.BOTTOM] = 10;
+          node_2.setMargin(Spacing.LEFT, 10);
+          node_2.setMargin(Spacing.TOP, 10);
+          node_2.setMargin(Spacing.RIGHT, 10);
+          node_2.setMargin(Spacing.BOTTOM, 10);
           node_2 = node_1.getChildAt(1);
           node_2.style.height = 100;
         }
@@ -2574,7 +2574,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.LEFT] = 10;
+        node_1.setMargin(Spacing.LEFT, 10);
       }
     }
 
@@ -2611,7 +2611,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.LEFT] = 10;
+        node_1.setMargin(Spacing.LEFT, 10);
       }
     }
 
@@ -2642,10 +2642,10 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.padding[Spacing.LEFT] = 5;
-      node_0.style.padding[Spacing.TOP] = 5;
-      node_0.style.padding[Spacing.RIGHT] = 5;
-      node_0.style.padding[Spacing.BOTTOM] = 5;
+      node_0.setPadding(Spacing.LEFT, 5);
+      node_0.setPadding(Spacing.TOP, 5);
+      node_0.setPadding(Spacing.RIGHT, 5);
+      node_0.setPadding(Spacing.BOTTOM, 5);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -2666,10 +2666,10 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.padding[Spacing.LEFT] = 5;
-      node_0.style.padding[Spacing.TOP] = 5;
-      node_0.style.padding[Spacing.RIGHT] = 5;
-      node_0.style.padding[Spacing.BOTTOM] = 5;
+      node_0.setPadding(Spacing.LEFT, 5);
+      node_0.setPadding(Spacing.TOP, 5);
+      node_0.setPadding(Spacing.RIGHT, 5);
+      node_0.setPadding(Spacing.BOTTOM, 5);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -2704,18 +2704,18 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.padding[Spacing.LEFT] = 5;
-      node_0.style.padding[Spacing.TOP] = 5;
-      node_0.style.padding[Spacing.RIGHT] = 5;
-      node_0.style.padding[Spacing.BOTTOM] = 5;
+      node_0.setPadding(Spacing.LEFT, 5);
+      node_0.setPadding(Spacing.TOP, 5);
+      node_0.setPadding(Spacing.RIGHT, 5);
+      node_0.setPadding(Spacing.BOTTOM, 5);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.LEFT] = 5;
-        node_1.style.margin[Spacing.TOP] = 5;
-        node_1.style.margin[Spacing.RIGHT] = 5;
-        node_1.style.margin[Spacing.BOTTOM] = 5;
+        node_1.setMargin(Spacing.LEFT, 5);
+        node_1.setMargin(Spacing.TOP, 5);
+        node_1.setMargin(Spacing.RIGHT, 5);
+        node_1.setMargin(Spacing.BOTTOM, 5);
       }
     }
 
@@ -2751,10 +2751,10 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.alignSelf = CSSAlign.STRETCH;
-        node_1.style.padding[Spacing.LEFT] = 10;
-        node_1.style.padding[Spacing.TOP] = 10;
-        node_1.style.padding[Spacing.RIGHT] = 10;
-        node_1.style.padding[Spacing.BOTTOM] = 10;
+        node_1.setPadding(Spacing.LEFT, 10);
+        node_1.setPadding(Spacing.TOP, 10);
+        node_1.setPadding(Spacing.RIGHT, 10);
+        node_1.setPadding(Spacing.BOTTOM, 10);
       }
     }
 
@@ -2785,19 +2785,19 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.padding[Spacing.LEFT] = 50;
-      node_0.style.padding[Spacing.TOP] = 50;
-      node_0.style.padding[Spacing.RIGHT] = 50;
-      node_0.style.padding[Spacing.BOTTOM] = 50;
+      node_0.setPadding(Spacing.LEFT, 50);
+      node_0.setPadding(Spacing.TOP, 50);
+      node_0.setPadding(Spacing.RIGHT, 50);
+      node_0.setPadding(Spacing.BOTTOM, 50);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.alignSelf = CSSAlign.STRETCH;
-        node_1.style.padding[Spacing.LEFT] = 10;
-        node_1.style.padding[Spacing.TOP] = 10;
-        node_1.style.padding[Spacing.RIGHT] = 10;
-        node_1.style.padding[Spacing.BOTTOM] = 10;
+        node_1.setPadding(Spacing.LEFT, 10);
+        node_1.setPadding(Spacing.TOP, 10);
+        node_1.setPadding(Spacing.RIGHT, 10);
+        node_1.setPadding(Spacing.BOTTOM, 10);
       }
     }
 
@@ -2837,10 +2837,10 @@ public class LayoutEngineTest {
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.style.margin[Spacing.LEFT] = 16;
-          node_2.style.margin[Spacing.TOP] = 16;
-          node_2.style.margin[Spacing.RIGHT] = 16;
-          node_2.style.margin[Spacing.BOTTOM] = 16;
+          node_2.setMargin(Spacing.LEFT, 16);
+          node_2.setMargin(Spacing.TOP, 16);
+          node_2.setMargin(Spacing.RIGHT, 16);
+          node_2.setMargin(Spacing.BOTTOM, 16);
         }
       }
     }
@@ -2905,7 +2905,7 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.justifyContent = CSSJustify.SPACE_AROUND;
       node_0.style.height = 10;
-      node_0.style.padding[Spacing.TOP] = 5;
+      node_0.setPadding(Spacing.TOP, 5);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -3040,7 +3040,7 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.positionType = CSSPositionType.ABSOLUTE;
-        node_1.style.margin[Spacing.RIGHT] = 15;
+        node_1.setMargin(Spacing.RIGHT, 15);
       }
     }
 
@@ -3077,7 +3077,7 @@ public class LayoutEngineTest {
         node_1 = node_0.getChildAt(0);
         node_1.style.alignSelf = CSSAlign.CENTER;
         node_1.style.positionType = CSSPositionType.ABSOLUTE;
-        node_1.style.padding[Spacing.RIGHT] = 12;
+        node_1.setPadding(Spacing.RIGHT, 12);
       }
     }
 
@@ -3109,7 +3109,7 @@ public class LayoutEngineTest {
     {
       TestCSSNode node_0 = root_node;
       node_0.style.height = 5;
-      node_0.style.padding[Spacing.BOTTOM] = 20;
+      node_0.setPadding(Spacing.BOTTOM, 20);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -3131,7 +3131,7 @@ public class LayoutEngineTest {
     {
       TestCSSNode node_0 = root_node;
       node_0.style.width = 5;
-      node_0.style.padding[Spacing.LEFT] = 20;
+      node_0.setPadding(Spacing.LEFT, 20);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -3209,10 +3209,10 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.padding[Spacing.LEFT] = 5;
-      node_0.style.padding[Spacing.TOP] = 5;
-      node_0.style.padding[Spacing.RIGHT] = 5;
-      node_0.style.padding[Spacing.BOTTOM] = 5;
+      node_0.setPadding(Spacing.LEFT, 5);
+      node_0.setPadding(Spacing.TOP, 5);
+      node_0.setPadding(Spacing.RIGHT, 5);
+      node_0.setPadding(Spacing.BOTTOM, 5);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -3292,10 +3292,10 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.padding[Spacing.LEFT] = 20;
-      node_0.style.padding[Spacing.TOP] = 20;
-      node_0.style.padding[Spacing.RIGHT] = 20;
-      node_0.style.padding[Spacing.BOTTOM] = 20;
+      node_0.setPadding(Spacing.LEFT, 20);
+      node_0.setPadding(Spacing.TOP, 20);
+      node_0.setPadding(Spacing.RIGHT, 20);
+      node_0.setPadding(Spacing.BOTTOM, 20);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -3337,7 +3337,7 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.positionType = CSSPositionType.ABSOLUTE;
-        node_1.style.margin[Spacing.TOP] = 5;
+        node_1.setMargin(Spacing.TOP, 5);
         node_1.style.positionTop = 5;
       }
     }
@@ -3374,7 +3374,7 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.positionType = CSSPositionType.ABSOLUTE;
-        node_1.style.margin[Spacing.LEFT] = 5;
+        node_1.setMargin(Spacing.LEFT, 5);
         node_1.style.positionLeft = 5;
       }
     }
@@ -3500,7 +3500,7 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.flex = 1;
-        node_1.style.margin[Spacing.LEFT] = 5;
+        node_1.setMargin(Spacing.LEFT, 5);
       }
     }
 
@@ -3539,7 +3539,7 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.flex = 1;
-        node_1.style.margin[Spacing.RIGHT] = 5;
+        node_1.setMargin(Spacing.RIGHT, 5);
       }
     }
 
@@ -3579,7 +3579,7 @@ public class LayoutEngineTest {
         node_1.style.flex = 1;
         node_1 = node_0.getChildAt(1);
         node_1.style.flex = 1;
-        node_1.style.padding[Spacing.RIGHT] = 5;
+        node_1.setPadding(Spacing.RIGHT, 5);
       }
     }
 
@@ -3625,7 +3625,7 @@ public class LayoutEngineTest {
         node_1.style.flex = 1;
         node_1 = node_0.getChildAt(1);
         node_1.style.flex = 1;
-        node_1.style.padding[Spacing.LEFT] = 5;
+        node_1.setPadding(Spacing.LEFT, 5);
       }
     }
 
@@ -3670,7 +3670,7 @@ public class LayoutEngineTest {
         node_1.style.flex = 1;
         node_1 = node_0.getChildAt(1);
         node_1.style.flex = 1;
-        node_1.style.margin[Spacing.LEFT] = 5;
+        node_1.setMargin(Spacing.LEFT, 5);
       }
     }
 
@@ -3716,7 +3716,7 @@ public class LayoutEngineTest {
         node_1.style.flex = 1;
         node_1 = node_0.getChildAt(1);
         node_1.style.flex = 1;
-        node_1.style.margin[Spacing.RIGHT] = 5;
+        node_1.setMargin(Spacing.RIGHT, 5);
       }
     }
 
@@ -3916,10 +3916,10 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.border[Spacing.LEFT] = 5;
-      node_0.style.border[Spacing.TOP] = 5;
-      node_0.style.border[Spacing.RIGHT] = 5;
-      node_0.style.border[Spacing.BOTTOM] = 5;
+      node_0.setBorder(Spacing.LEFT, 5);
+      node_0.setBorder(Spacing.TOP, 5);
+      node_0.setBorder(Spacing.RIGHT, 5);
+      node_0.setBorder(Spacing.BOTTOM, 5);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -3940,7 +3940,7 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.border[Spacing.TOP] = 1;
+      node_0.setBorder(Spacing.TOP, 1);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -3977,10 +3977,10 @@ public class LayoutEngineTest {
     TestCSSNode root_node = new TestCSSNode();
     {
       TestCSSNode node_0 = root_node;
-      node_0.style.border[Spacing.LEFT] = 1;
-      node_0.style.border[Spacing.TOP] = 1;
-      node_0.style.border[Spacing.RIGHT] = 1;
-      node_0.style.border[Spacing.BOTTOM] = 1;
+      node_0.setBorder(Spacing.LEFT, 1);
+      node_0.setBorder(Spacing.TOP, 1);
+      node_0.setBorder(Spacing.RIGHT, 1);
+      node_0.setBorder(Spacing.BOTTOM, 1);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -4023,11 +4023,11 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.alignSelf = CSSAlign.STRETCH;
-        node_1.style.margin[Spacing.LEFT] = 20;
-        node_1.style.padding[Spacing.LEFT] = 20;
-        node_1.style.padding[Spacing.TOP] = 20;
-        node_1.style.padding[Spacing.RIGHT] = 20;
-        node_1.style.padding[Spacing.BOTTOM] = 20;
+        node_1.setMargin(Spacing.LEFT, 20);
+        node_1.setPadding(Spacing.LEFT, 20);
+        node_1.setPadding(Spacing.TOP, 20);
+        node_1.setPadding(Spacing.RIGHT, 20);
+        node_1.setPadding(Spacing.BOTTOM, 20);
       }
     }
 
@@ -4063,7 +4063,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.border[Spacing.RIGHT] = 5;
+        node_1.setBorder(Spacing.RIGHT, 5);
       }
     }
 
@@ -4095,12 +4095,12 @@ public class LayoutEngineTest {
     {
       TestCSSNode node_0 = root_node;
       node_0.style.flexDirection = CSSFlexDirection.ROW;
-      node_0.style.border[Spacing.RIGHT] = 1;
+      node_0.setBorder(Spacing.RIGHT, 1);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.RIGHT] = -8;
+        node_1.setMargin(Spacing.RIGHT, -8);
       }
     }
 
@@ -4133,12 +4133,12 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.direction = CSSDirection.RTL;
       node_0.style.flexDirection = CSSFlexDirection.ROW;
-      node_0.style.border[Spacing.LEFT] = 1;
+      node_0.setBorder(Spacing.LEFT, 1);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.LEFT] = -8;
+        node_1.setMargin(Spacing.LEFT, -8);
       }
     }
 
@@ -4542,19 +4542,19 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.alignSelf = CSSAlign.FLEX_START;
       node_0.style.width = 100;
-      node_0.style.padding[Spacing.LEFT] = 10;
-      node_0.style.padding[Spacing.TOP] = 10;
-      node_0.style.padding[Spacing.RIGHT] = 10;
-      node_0.style.padding[Spacing.BOTTOM] = 10;
+      node_0.setPadding(Spacing.LEFT, 10);
+      node_0.setPadding(Spacing.TOP, 10);
+      node_0.setPadding(Spacing.RIGHT, 10);
+      node_0.setPadding(Spacing.BOTTOM, 10);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.alignSelf = CSSAlign.FLEX_START;
-        node_1.style.margin[Spacing.LEFT] = 10;
-        node_1.style.margin[Spacing.TOP] = 10;
-        node_1.style.margin[Spacing.RIGHT] = 10;
-        node_1.style.margin[Spacing.BOTTOM] = 10;
+        node_1.setMargin(Spacing.LEFT, 10);
+        node_1.setMargin(Spacing.TOP, 10);
+        node_1.setMargin(Spacing.RIGHT, 10);
+        node_1.setMargin(Spacing.BOTTOM, 10);
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -4775,10 +4775,10 @@ public class LayoutEngineTest {
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.style.margin[Spacing.LEFT] = 20;
-          node_2.style.margin[Spacing.TOP] = 20;
-          node_2.style.margin[Spacing.RIGHT] = 20;
-          node_2.style.margin[Spacing.BOTTOM] = 20;
+          node_2.setMargin(Spacing.LEFT, 20);
+          node_2.setMargin(Spacing.TOP, 20);
+          node_2.setMargin(Spacing.RIGHT, 20);
+          node_2.setMargin(Spacing.BOTTOM, 20);
           node_2.setMeasureFunction(sTestMeasureFunction);
           node_2.context = "loooooooooong with space";
         }
@@ -4832,10 +4832,10 @@ public class LayoutEngineTest {
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.style.margin[Spacing.LEFT] = 20;
-          node_2.style.margin[Spacing.TOP] = 20;
-          node_2.style.margin[Spacing.RIGHT] = 20;
-          node_2.style.margin[Spacing.BOTTOM] = 20;
+          node_2.setMargin(Spacing.LEFT, 20);
+          node_2.setMargin(Spacing.TOP, 20);
+          node_2.setMargin(Spacing.RIGHT, 20);
+          node_2.setMargin(Spacing.BOTTOM, 20);
           node_2.setMeasureFunction(sTestMeasureFunction);
           node_2.context = "loooooooooong with space";
         }
@@ -4887,10 +4887,10 @@ public class LayoutEngineTest {
         {
           TestCSSNode node_2;
           node_2 = node_1.getChildAt(0);
-          node_2.style.margin[Spacing.LEFT] = 20;
-          node_2.style.margin[Spacing.TOP] = 20;
-          node_2.style.margin[Spacing.RIGHT] = 20;
-          node_2.style.margin[Spacing.BOTTOM] = 20;
+          node_2.setMargin(Spacing.LEFT, 20);
+          node_2.setMargin(Spacing.TOP, 20);
+          node_2.setMargin(Spacing.RIGHT, 20);
+          node_2.setMargin(Spacing.BOTTOM, 20);
           node_2.setMeasureFunction(sTestMeasureFunction);
           node_2.context = "loooooooooong with space";
         }
@@ -5487,7 +5487,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.border[Spacing.BOTTOM] = 1;
+        node_1.setBorder(Spacing.BOTTOM, 1);
       }
     }
 
@@ -5523,7 +5523,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.TOP] = -6;
+        node_1.setMargin(Spacing.TOP, -6);
       }
     }
 
@@ -5559,7 +5559,7 @@ public class LayoutEngineTest {
       {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
-        node_1.style.margin[Spacing.TOP] = 20;
+        node_1.setMargin(Spacing.TOP, 20);
       }
     }
 
@@ -5591,7 +5591,7 @@ public class LayoutEngineTest {
     {
       TestCSSNode node_0 = root_node;
       node_0.style.justifyContent = CSSJustify.FLEX_END;
-      node_0.style.border[Spacing.BOTTOM] = 5;
+      node_0.setBorder(Spacing.BOTTOM, 5);
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -5981,10 +5981,10 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.maxWidth = 30;
       node_0.style.maxHeight = 10;
-      node_0.style.padding[Spacing.LEFT] = 20;
-      node_0.style.padding[Spacing.TOP] = 15;
-      node_0.style.padding[Spacing.RIGHT] = 20;
-      node_0.style.padding[Spacing.BOTTOM] = 15;
+      node_0.setPadding(Spacing.LEFT, 20);
+      node_0.setPadding(Spacing.TOP, 15);
+      node_0.setPadding(Spacing.RIGHT, 20);
+      node_0.setPadding(Spacing.BOTTOM, 15);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -6007,10 +6007,10 @@ public class LayoutEngineTest {
       TestCSSNode node_0 = root_node;
       node_0.style.minWidth = 50;
       node_0.style.minHeight = 40;
-      node_0.style.padding[Spacing.LEFT] = 20;
-      node_0.style.padding[Spacing.TOP] = 15;
-      node_0.style.padding[Spacing.RIGHT] = 20;
-      node_0.style.padding[Spacing.BOTTOM] = 15;
+      node_0.setPadding(Spacing.LEFT, 20);
+      node_0.setPadding(Spacing.TOP, 15);
+      node_0.setPadding(Spacing.RIGHT, 20);
+      node_0.setPadding(Spacing.BOTTOM, 15);
     }
 
     TestCSSNode root_layout = new TestCSSNode();
@@ -7122,10 +7122,10 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.positionType = CSSPositionType.ABSOLUTE;
-        node_1.style.padding[Spacing.LEFT] = 10;
-        node_1.style.padding[Spacing.TOP] = 10;
-        node_1.style.padding[Spacing.RIGHT] = 10;
-        node_1.style.padding[Spacing.BOTTOM] = 10;
+        node_1.setPadding(Spacing.LEFT, 10);
+        node_1.setPadding(Spacing.TOP, 10);
+        node_1.setPadding(Spacing.RIGHT, 10);
+        node_1.setPadding(Spacing.BOTTOM, 10);
         node_1.style.positionLeft = 100;
         node_1.style.positionTop = 100;
         node_1.style.positionRight = 100;
@@ -7186,14 +7186,14 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.positionType = CSSPositionType.ABSOLUTE;
-        node_1.style.padding[Spacing.LEFT] = 10;
-        node_1.style.padding[Spacing.TOP] = 10;
-        node_1.style.padding[Spacing.RIGHT] = 10;
-        node_1.style.padding[Spacing.BOTTOM] = 10;
-        node_1.style.border[Spacing.LEFT] = 1;
-        node_1.style.border[Spacing.TOP] = 1;
-        node_1.style.border[Spacing.RIGHT] = 1;
-        node_1.style.border[Spacing.BOTTOM] = 1;
+        node_1.setPadding(Spacing.LEFT, 10);
+        node_1.setPadding(Spacing.TOP, 10);
+        node_1.setPadding(Spacing.RIGHT, 10);
+        node_1.setPadding(Spacing.BOTTOM, 10);
+        node_1.setBorder(Spacing.LEFT, 1);
+        node_1.setBorder(Spacing.TOP, 1);
+        node_1.setBorder(Spacing.RIGHT, 1);
+        node_1.setBorder(Spacing.BOTTOM, 1);
         node_1.style.positionLeft = 100;
         node_1.style.positionTop = 100;
         node_1.style.positionRight = 100;
@@ -7254,10 +7254,10 @@ public class LayoutEngineTest {
         TestCSSNode node_1;
         node_1 = node_0.getChildAt(0);
         node_1.style.flex = 1;
-        node_1.style.padding[Spacing.LEFT] = 10;
-        node_1.style.padding[Spacing.TOP] = 10;
-        node_1.style.padding[Spacing.RIGHT] = 10;
-        node_1.style.padding[Spacing.BOTTOM] = 10;
+        node_1.setPadding(Spacing.LEFT, 10);
+        node_1.setPadding(Spacing.TOP, 10);
+        node_1.setPadding(Spacing.RIGHT, 10);
+        node_1.setPadding(Spacing.BOTTOM, 10);
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;


### PR DESCRIPTION
Using float arrays for spacing everywhere is silly and makes calculations hard. This patch makes Spacing an actual object (not just a util class) that holds on to style-set spacing and default spacing (e.g. for native components defining their own padding).

Also, this makes default spacing resolution happen in `get()`, so that the order in which `set()` and `setDefault()` are called doesn't matter anymore. Before, with `updateSpacing()`, setting default spacing overwrote style-set spacing.