### PR TITLE
Expose the resolved direction in the node's layout

### DIFF
--- a/src/JavaTranspiler.js
+++ b/src/JavaTranspiler.js
@@ -38,6 +38,9 @@ function __transpileToJavaCommon(code) {
     .replace(
         /(\w+)\.layout\[((?:getTrailing|getPos)\([^\)]+\))\]\s+=\s+([^;]+);/gm,
         'setLayoutPosition($1, $2, $3);')
+    .replace(
+        /(\w+)\.layout\.direction\s+=\s+([^;]+);/gm,
+        'setLayoutDirection($1, $2);')
     .replace(/(\w+)\.layout\[((?:getLeading|getPos)\([^\]]+\))\]/g, 'getLayoutPosition($1, $2)')
     .replace(/(\w+)\.layout\[((?:getTrailing|getPos)\([^\]]+\))\]/g, 'getLayoutPosition($1, $2)')
     .replace(

--- a/src/Layout.c
+++ b/src/Layout.c
@@ -536,6 +536,9 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth, css_direction
   setDimensionFromStyle(node, mainAxis);
   setDimensionFromStyle(node, crossAxis);
 
+  // Set the resolved resolution in the node's layout
+  node->layout.direction = direction;
+
   // The position is set by the parent, but we need to complete it with a
   // delta composed of the margin and left/top/right/bottom
   node->layout.position[leading[mainAxis]] += getLeadingMargin(node, mainAxis) +

--- a/src/Layout.h
+++ b/src/Layout.h
@@ -84,6 +84,7 @@ typedef enum {
 typedef struct {
   float position[4];
   float dimensions[2];
+  css_direction_t direction;
 
   // Instead of recomputing the entire layout every single time, we
   // cache some information to break early when nothing changed

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -111,6 +111,7 @@ var computeLayout = (function() {
 
     delete layout.right;
     delete layout.bottom;
+    delete layout.direction;
 
     return layout;
   }
@@ -406,6 +407,9 @@ var computeLayout = (function() {
     // Handle width and height style attributes
     setDimensionFromStyle(node, mainAxis);
     setDimensionFromStyle(node, crossAxis);
+
+    // Set the resolved resolution in the node's layout
+    node.layout.direction = direction;
 
     // The position is set by the parent, but we need to complete it with a
     // delta composed of the margin and left/top/right/bottom

--- a/src/java/src/com/facebook/csslayout/CSSLayout.java
+++ b/src/java/src/com/facebook/csslayout/CSSLayout.java
@@ -19,6 +19,7 @@ public class CSSLayout {
   public float bottom;
   public float width = CSSConstants.UNDEFINED;
   public float height = CSSConstants.UNDEFINED;
+  public CSSDirection direction = CSSDirection.LTR;
 
   /**
    * This should always get called before calling {@link LayoutEngine#layoutNode(CSSNode, float)}
@@ -30,6 +31,7 @@ public class CSSLayout {
     bottom = 0;
     width = CSSConstants.UNDEFINED;
     height = CSSConstants.UNDEFINED;
+    direction = CSSDirection.LTR;
   }
 
   public void copy(CSSLayout layout) {
@@ -39,6 +41,7 @@ public class CSSLayout {
     bottom = layout.bottom;
     width = layout.width;
     height = layout.height;
+    direction = layout.direction;
   }
 
   @Override
@@ -48,6 +51,7 @@ public class CSSLayout {
         "top: " + top + ", " +
         "width: " + width + ", " +
         "height: " + height +
+        "direction: " + direction +
         "}";
   }
 }

--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -211,6 +211,13 @@ public class CSSNode {
     return o1.equals(o2);
   }
 
+  public void setDirection(CSSDirection direction) {
+    if (!valuesEqual(style.direction, direction)) {
+      style.direction = direction;
+      dirty();
+    }
+  }
+
   public void setFlexDirection(CSSFlexDirection flexDirection) {
     if (!valuesEqual(style.flexDirection, flexDirection)) {
       style.flexDirection = flexDirection;
@@ -334,6 +341,10 @@ public class CSSNode {
 
   public float getLayoutHeight() {
     return layout.height;
+  }
+
+  public CSSDirection getLayoutDirection() {
+    return layout.direction;
   }
 
   /**

--- a/src/java/src/com/facebook/csslayout/LayoutEngine.java
+++ b/src/java/src/com/facebook/csslayout/LayoutEngine.java
@@ -85,6 +85,10 @@ public class LayoutEngine {
     }
   }
 
+  private static void setLayoutDirection(CSSNode node, CSSDirection direction) {
+    node.layout.direction = direction;
+  }
+
   private static float getStylePosition(CSSNode node, PositionIndex position) {
     switch (position) {
       case TOP:
@@ -520,6 +524,9 @@ public class LayoutEngine {
     // Handle width and height style attributes
     setDimensionFromStyle(node, mainAxis);
     setDimensionFromStyle(node, crossAxis);
+  
+    // Set the resolved resolution in the node's layout
+    setLayoutDirection(node, direction);
   
     // The position is set by the parent, but we need to complete it with a
     // delta composed of the margin and left/top/right/bottom


### PR DESCRIPTION
We'll need a way to know the resolved direction of a node so that we can use this information when measuring it.