### PR TITLE
Flex bug

### DIFF
--- a/src/Layout-test-utils.c
+++ b/src/Layout-test-utils.c
@@ -29,7 +29,7 @@ __forceinline const float fminf(const float a, const float b) {
 #define SMALL_WIDTH 35
 #define SMALL_HEIGHT 18
 #define BIG_WIDTH 172
-#define BIG_HEIGHT 37
+#define BIG_HEIGHT 36
 #define BIG_MIN_WIDTH 100
 #define SMALL_TEXT "small"
 #define LONG_TEXT "loooooooooong with space"

--- a/src/Layout-test-utils.js
+++ b/src/Layout-test-utils.js
@@ -408,7 +408,7 @@ var layoutTestUtils = (function() {
     smallWidth: 34.671875,
     smallHeight: 18,
     bigWidth: 172.421875,
-    bigHeight: 37,
+    bigHeight: 36,
     bigMinWidth: 100.4375
   };
 

--- a/src/__tests__/Layout-test.c
+++ b/src/__tests__/Layout-test.c
@@ -4192,7 +4192,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 130;
-      node_0->layout.dimensions[CSS_HEIGHT] = 37;
+      node_0->layout.dimensions[CSS_HEIGHT] = 36;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -4200,7 +4200,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 130;
-        node_1->layout.dimensions[CSS_HEIGHT] = 37;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -4208,7 +4208,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
           node_2->layout.dimensions[CSS_WIDTH] = 130;
-          node_2->layout.dimensions[CSS_HEIGHT] = 37;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }
@@ -4244,7 +4244,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 200;
-      node_0->layout.dimensions[CSS_HEIGHT] = 37;
+      node_0->layout.dimensions[CSS_HEIGHT] = 36;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -4252,7 +4252,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 200;
-        node_1->layout.dimensions[CSS_HEIGHT] = 37;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -4260,7 +4260,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
           node_2->layout.dimensions[CSS_WIDTH] = 130;
-          node_2->layout.dimensions[CSS_HEIGHT] = 37;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }
@@ -4290,7 +4290,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 100;
-      node_0->layout.dimensions[CSS_HEIGHT] = 37;
+      node_0->layout.dimensions[CSS_HEIGHT] = 36;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -4298,7 +4298,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 100;
-        node_1->layout.dimensions[CSS_HEIGHT] = 37;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
       }
     }
 
@@ -4344,7 +4344,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 100;
-      node_0->layout.dimensions[CSS_HEIGHT] = 77;
+      node_0->layout.dimensions[CSS_HEIGHT] = 76;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -4352,7 +4352,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 20;
         node_1->layout.position[CSS_LEFT] = 20;
         node_1->layout.dimensions[CSS_WIDTH] = 100;
-        node_1->layout.dimensions[CSS_HEIGHT] = 37;
+        node_1->layout.dimensions[CSS_HEIGHT] = 36;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -4360,7 +4360,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 0;
           node_2->layout.position[CSS_LEFT] = 0;
           node_2->layout.dimensions[CSS_WIDTH] = 100;
-          node_2->layout.dimensions[CSS_HEIGHT] = 37;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }
@@ -4668,7 +4668,7 @@ int main()
       node_0->layout.position[CSS_TOP] = 0;
       node_0->layout.position[CSS_LEFT] = 0;
       node_0->layout.dimensions[CSS_WIDTH] = 200;
-      node_0->layout.dimensions[CSS_HEIGHT] = 77;
+      node_0->layout.dimensions[CSS_HEIGHT] = 76;
       init_css_node_children(node_0, 1);
       {
         css_node_t *node_1;
@@ -4676,7 +4676,7 @@ int main()
         node_1->layout.position[CSS_TOP] = 0;
         node_1->layout.position[CSS_LEFT] = 0;
         node_1->layout.dimensions[CSS_WIDTH] = 200;
-        node_1->layout.dimensions[CSS_HEIGHT] = 77;
+        node_1->layout.dimensions[CSS_HEIGHT] = 76;
         init_css_node_children(node_1, 1);
         {
           css_node_t *node_2;
@@ -4684,7 +4684,7 @@ int main()
           node_2->layout.position[CSS_TOP] = 20;
           node_2->layout.position[CSS_LEFT] = 20;
           node_2->layout.dimensions[CSS_WIDTH] = 160;
-          node_2->layout.dimensions[CSS_HEIGHT] = 37;
+          node_2->layout.dimensions[CSS_HEIGHT] = 36;
         }
       }
     }

--- a/src/__tests__/Layout-test.js
+++ b/src/__tests__/Layout-test.js
@@ -2307,6 +2307,21 @@ describe('Layout', function() {
       ]}
     );
   });
+
+  xit('should stretch a nested child', function() {
+    testLayout(
+      {children: [
+        {children: [{}]},
+        {style: {width: 40}}
+      ]},
+      {width: 40, height: 0, top: 0, left: 0, children: [
+        {width: 40, height: 0, top: 0, left: 0, children: [
+          {width: 40, height: 0, top: 0, left: 0}
+        ]},
+        {width: 40, height: 0, top: 0, left: 0}
+      ]}
+    );
+  });
 });
 
 describe('Layout alignContent', function() {
@@ -2396,21 +2411,4 @@ describe('Layout alignContent', function() {
   testAlignContent('flex-end', 'center');
   testAlignContent('flex-end', 'flex-end');
   testAlignContent('flex-end', 'stretch');
-});
-
-describe('nested flex', function() {
-  it('should stretch a nested child', function() {
-    testLayout(
-      {children: [
-        {children: [{}]},
-        {style: {width: 40}}
-      ]},
-      {width: 40, height: 0, top: 0, left: 0, children: [
-        {width: 40, height: 0, top: 0, left: 0, children: [
-          {width: 40, height: 0, top: 0, left: 0}
-        ]},
-        {width: 40, height: 0, top: 0, left: 0}
-      ]}
-    );
-  });
 });

--- a/src/__tests__/Layout-test.js
+++ b/src/__tests__/Layout-test.js
@@ -2397,3 +2397,20 @@ describe('Layout alignContent', function() {
   testAlignContent('flex-end', 'flex-end');
   testAlignContent('flex-end', 'stretch');
 });
+
+describe('nested flex', function() {
+  it('should stretch a nested child', function() {
+    testLayout(
+      {children: [
+        {children: [{}]},
+        {style: {width: 40}}
+      ]},
+      {width: 40, height: 0, top: 0, left: 0, children: [
+        {width: 40, height: 0, top: 0, left: 0, children: [
+          {width: 40, height: 0, top: 0, left: 0}
+        ]},
+        {width: 40, height: 0, top: 0, left: 0}
+      ]}
+    );
+  });
+});

--- a/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
+++ b/src/java/tests/com/facebook/csslayout/LayoutEngineTest.java
@@ -4469,7 +4469,7 @@ public class LayoutEngineTest {
       node_0.layout.top = 0;
       node_0.layout.left = 0;
       node_0.layout.width = 130;
-      node_0.layout.height = 37;
+      node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -4477,7 +4477,7 @@ public class LayoutEngineTest {
         node_1.layout.top = 0;
         node_1.layout.left = 0;
         node_1.layout.width = 130;
-        node_1.layout.height = 37;
+        node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -4485,7 +4485,7 @@ public class LayoutEngineTest {
           node_2.layout.top = 0;
           node_2.layout.left = 0;
           node_2.layout.width = 130;
-          node_2.layout.height = 37;
+          node_2.layout.height = 36;
         }
       }
     }
@@ -4523,7 +4523,7 @@ public class LayoutEngineTest {
       node_0.layout.top = 0;
       node_0.layout.left = 0;
       node_0.layout.width = 200;
-      node_0.layout.height = 37;
+      node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -4531,7 +4531,7 @@ public class LayoutEngineTest {
         node_1.layout.top = 0;
         node_1.layout.left = 0;
         node_1.layout.width = 200;
-        node_1.layout.height = 37;
+        node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -4539,7 +4539,7 @@ public class LayoutEngineTest {
           node_2.layout.top = 0;
           node_2.layout.left = 0;
           node_2.layout.width = 130;
-          node_2.layout.height = 37;
+          node_2.layout.height = 36;
         }
       }
     }
@@ -4571,7 +4571,7 @@ public class LayoutEngineTest {
       node_0.layout.top = 0;
       node_0.layout.left = 0;
       node_0.layout.width = 100;
-      node_0.layout.height = 37;
+      node_0.layout.height = 36;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -4579,7 +4579,7 @@ public class LayoutEngineTest {
         node_1.layout.top = 0;
         node_1.layout.left = 0;
         node_1.layout.width = 100;
-        node_1.layout.height = 37;
+        node_1.layout.height = 36;
       }
     }
 
@@ -4627,7 +4627,7 @@ public class LayoutEngineTest {
       node_0.layout.top = 0;
       node_0.layout.left = 0;
       node_0.layout.width = 100;
-      node_0.layout.height = 77;
+      node_0.layout.height = 76;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -4635,7 +4635,7 @@ public class LayoutEngineTest {
         node_1.layout.top = 20;
         node_1.layout.left = 20;
         node_1.layout.width = 100;
-        node_1.layout.height = 37;
+        node_1.layout.height = 36;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -4643,7 +4643,7 @@ public class LayoutEngineTest {
           node_2.layout.top = 0;
           node_2.layout.left = 0;
           node_2.layout.width = 100;
-          node_2.layout.height = 37;
+          node_2.layout.height = 36;
         }
       }
     }
@@ -4965,7 +4965,7 @@ public class LayoutEngineTest {
       node_0.layout.top = 0;
       node_0.layout.left = 0;
       node_0.layout.width = 200;
-      node_0.layout.height = 77;
+      node_0.layout.height = 76;
       addChildren(node_0, 1);
       {
         TestCSSNode node_1;
@@ -4973,7 +4973,7 @@ public class LayoutEngineTest {
         node_1.layout.top = 0;
         node_1.layout.left = 0;
         node_1.layout.width = 200;
-        node_1.layout.height = 77;
+        node_1.layout.height = 76;
         addChildren(node_1, 1);
         {
           TestCSSNode node_2;
@@ -4981,7 +4981,7 @@ public class LayoutEngineTest {
           node_2.layout.top = 20;
           node_2.layout.left = 20;
           node_2.layout.width = 160;
-          node_2.layout.height = 37;
+          node_2.layout.height = 36;
         }
       }
     }

--- a/src/java/tests/com/facebook/csslayout/TestConstants.java
+++ b/src/java/tests/com/facebook/csslayout/TestConstants.java
@@ -17,7 +17,7 @@ public class TestConstants {
   public static final float SMALL_WIDTH = 35f;
   public static final float SMALL_HEIGHT = 18f;
   public static final float BIG_WIDTH = 172f;
-  public static final float BIG_HEIGHT = 37f;
+  public static final float BIG_HEIGHT = 36f;
   public static final float BIG_MIN_WIDTH = 100f;
   public static final String SMALL_TEXT = "small";
   public static final String LONG_TEXT = "loooooooooong with space";


### PR DESCRIPTION
Here's a bug in the flexbox calculation

```js
  <View>
    <View>
      <Text style={{backgroundColor: 'red'}}>Awesome</Text>
    </View>
    <View style={{width: 400, height: 20}}/>
  </View>
```

![image](https://cloud.githubusercontent.com/assets/112170/9117266/eb416f50-3c1d-11e5-934c-3361c18ffb7c.png)

I added a failing test, but I don't immediately know where I would go to fix it.