### PR TITLE
Windows build, package C, and updated README

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,11 +19,6 @@ module.exports = function(grunt) {
     javaTestFiles: 'org.junit.runner.JUnitCore com.facebook.csslayout.LayoutEngineTest com.facebook.csslayout.LayoutCachingTest com.facebook.csslayout.CSSNodeTest'
   };
 
-  // Create the dist folder if it doesn't exist. It is deleted by the 'clean' task.
-  if (!fs.existsSync(config.distFolder)){
-    fs.mkdirSync(config.distFolder);
-  }
-
   // C compilation configuration
   if (isWindows) {
     // Windows build, assumes cl is in the path (see https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx).
@@ -41,8 +36,15 @@ module.exports = function(grunt) {
   }
 
   grunt.initConfig({
-
     config: config,
+
+    mkdir: {
+      dist: {
+        options: {
+          create: ['<%= config.distFolder %>']
+        },
+      },
+    },
 
     clean: {
       dist: ['<%= config.distFolder %>'],
@@ -163,13 +165,13 @@ module.exports = function(grunt) {
   grunt.registerTask('test-javascript', ['eslint', 'karma']);
 
   // Packages the JavaScript as a single UMD module and minifies
-  grunt.registerTask('package-javascript', ['includereplace', 'uglify']);
+  grunt.registerTask('package-javascript', ['mkdir:dist', 'includereplace', 'uglify']);
 
   // Packages the Java as a JAR
-  grunt.registerTask('package-java', ['shell:javaPackage']);
+  grunt.registerTask('package-java', ['mkdir:dist', 'shell:javaPackage']);
 
   // Packages the C code as a single header
-  grunt.registerTask('package-c', ['concat']);
+  grunt.registerTask('package-c', ['mkdir:dist', 'concat']);
 
   // Default build, performs the full works!
   grunt.registerTask('build', ['test-javascript', 'transpile', 'clean:dist', 'package-javascript', 'package-java', 'package-c']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,10 +6,10 @@ module.exports = function(grunt) {
   var isWindows = /^win/.test(process.platform);
 
   require('load-grunt-tasks')(grunt);
-  grunt.loadNpmTasks('grunt-contrib-concat');
 
   // config
   var config = {
+    delimiter: path.delimiter,
     libName: 'css-layout',
     distFolder: 'dist',
     srcFolder: 'src',
@@ -25,20 +25,19 @@ module.exports = function(grunt) {
   }
 
   // C compilation configuration
-  var cTestClean, cTestCompile, cTestExecute;
   if (isWindows) {
     // Windows build, assumes cl is in the path (see https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx).
     config.cTestOutput = 'c_test.exe';
-    cTestCompile = 'cl -nologo -Zi -Tpsrc/__tests__/Layout-test.c -Tpsrc/Layout.c -Tpsrc/Layout-test-utils.c -link -incremental:no -out:"<%= config.cTestOutput %>"';
-    cTestExecute = '<%= config.cTestOutput %>';
-    cTestClean = ['<%= config.cTestOutput %>','*.obj','*.pdb'];
+    config.cTestCompile = 'cl -nologo -Zi -Tpsrc/__tests__/Layout-test.c -Tpsrc/Layout.c -Tpsrc/Layout-test-utils.c -link -incremental:no -out:"<%= config.cTestOutput %>"';
+    config.cTestExecute = '<%= config.cTestOutput %>';
+    config.cTestClean = ['<%= config.cTestOutput %>','*.obj','*.pdb'];
   }
   else {
     // GCC build (OSX, Linux, ...), assumes gcc is in the path.
     config.cTestOutput = 'c_test';
-    cTestCompile = 'gcc -std=c99 -Werror -Wno-padded src/__tests__/Layout-test.c src/Layout.c src/Layout-test-utils.c -lm -o "./<%= config.cTestOutput %>"';
-    cTestExecute = './<%= config.cTestOutput %>';
-    cTestClean = ['<%= config.cTestOutput %>'];
+    config.cTestCompile = 'gcc -std=c99 -Werror -Wno-padded src/__tests__/Layout-test.c src/Layout.c src/Layout-test-utils.c -lm -o "./<%= config.cTestOutput %>"';
+    config.cTestExecute = './<%= config.cTestOutput %>';
+    config.cTestClean = ['<%= config.cTestOutput %>'];
   }
 
   grunt.initConfig({
@@ -47,7 +46,7 @@ module.exports = function(grunt) {
 
     clean: {
       dist: ['<%= config.distFolder %>'],
-      cTest: cTestClean,
+      cTest: config.cTestClean,
       javaTest: ['**/*.class']
     },
 
@@ -134,25 +133,16 @@ module.exports = function(grunt) {
 
     shell: {
       cCompile: {
-        command: cTestCompile
+        command: config.cTestCompile
       },
       cTestExecute: {
-        command: cTestExecute
+        command: config.cTestExecute
       },
       javaCompile: {
-        command: 'javac -cp <%= config.javaLibFolder %>/junit4.jar' +
-          path.delimiter + '<%= config.javaLibFolder %>/jsr305.jar' +
-          path.delimiter + '<%= config.javaLibFolder %>/infer-annotations-1.4.jar' +
-          ' -sourcepath ./src/java/src' +
-          path.delimiter + './src/java/tests' +
-          ' <%= config.javaSource %>'
+        command: 'javac -cp <%= config.javaLibFolder %>/junit4.jar<%= config.delimiter %><%= config.javaLibFolder %>/jsr305.jar<%= config.delimiter %><%= config.javaLibFolder %>/infer-annotations-1.4.jar' + ' -sourcepath ./src/java/src<%= config.delimiter %>./src/java/tests' + ' <%= config.javaSource %>'
       },
       javaTestExecute: {
-        command: 'java -cp ./src/java/src' +
-          path.delimiter + './src/java/tests' +
-          path.delimiter + '<%= config.javaLibFolder %>/junit4.jar' +
-          path.delimiter + '<%= config.javaLibFolder %>/infer-annotations-1.4.jar' +
-          ' <%= config.javaTestFiles %>'
+        command: 'java -cp ./src/java/src<%= config.delimiter %>./src/java/tests<%= config.delimiter %><%= config.javaLibFolder %>/junit4.jar<%= config.delimiter %><%= config.javaLibFolder %>/infer-annotations-1.4.jar <%= config.javaTestFiles %>'
       },
       javaPackage: {
         command: 'jar cf <%= config.distFolder %>/<%= config.libName %>.jar <%= config.javaSource %>'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ padding, paddingLeft, paddingRight, paddingTop, paddingBottom | positive number
 borderWidth, borderLeftWidth, borderRightWidth, borderTopWidth, borderBottomWidth | positive number
 flexDirection | 'column', 'row'
 justifyContent | 'flex-start', 'center', 'flex-end', 'space-between', 'space-around'
-alignItems, alignSelf | 'flex-start', 'center', 'flex-end', 'stretch'
+alignItems, alignSelf, alignContent | 'flex-start', 'center', 'flex-end', 'stretch'
 flex | positive number
 flexWrap | 'wrap', 'nowrap'
 position | 'relative', 'absolute'
@@ -65,6 +65,7 @@ div, span {
   flex-direction: column;
   align-items: stretch;
   flex-shrink: 0;
+  align-content: flex-start;
 
   border: 0 solid black;
   margin: 0;

--- a/dist/css-layout.h
+++ b/dist/css-layout.h
@@ -1,3 +1,172 @@
+/*
+ * #define CSS_LAYOUT_IMPLEMENTATION
+ * before you include this file in *one* C or C++ file to create the implementation.
+ */
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef __LAYOUT_H
+#define __LAYOUT_H
+
+#include <math.h>
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+// Not defined in MSVC++
+#ifndef NAN
+static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
+#define NAN (*(const float *)__nan)
+#endif
+
+#define CSS_UNDEFINED NAN
+
+typedef enum {
+  CSS_DIRECTION_INHERIT = 0,
+  CSS_DIRECTION_LTR,
+  CSS_DIRECTION_RTL
+} css_direction_t;
+
+typedef enum {
+  CSS_FLEX_DIRECTION_COLUMN = 0,
+  CSS_FLEX_DIRECTION_COLUMN_REVERSE,
+  CSS_FLEX_DIRECTION_ROW,
+  CSS_FLEX_DIRECTION_ROW_REVERSE
+} css_flex_direction_t;
+
+typedef enum {
+  CSS_JUSTIFY_FLEX_START = 0,
+  CSS_JUSTIFY_CENTER,
+  CSS_JUSTIFY_FLEX_END,
+  CSS_JUSTIFY_SPACE_BETWEEN,
+  CSS_JUSTIFY_SPACE_AROUND
+} css_justify_t;
+
+// Note: auto is only a valid value for alignSelf. It is NOT a valid value for
+// alignItems.
+typedef enum {
+  CSS_ALIGN_AUTO = 0,
+  CSS_ALIGN_FLEX_START,
+  CSS_ALIGN_CENTER,
+  CSS_ALIGN_FLEX_END,
+  CSS_ALIGN_STRETCH
+} css_align_t;
+
+typedef enum {
+  CSS_POSITION_RELATIVE = 0,
+  CSS_POSITION_ABSOLUTE
+} css_position_type_t;
+
+typedef enum {
+  CSS_NOWRAP = 0,
+  CSS_WRAP
+} css_wrap_type_t;
+
+// Note: left and top are shared between position[2] and position[4], so
+// they have to be before right and bottom.
+typedef enum {
+  CSS_LEFT = 0,
+  CSS_TOP,
+  CSS_RIGHT,
+  CSS_BOTTOM,
+  CSS_START,
+  CSS_END,
+  CSS_POSITION_COUNT
+} css_position_t;
+
+typedef enum {
+  CSS_WIDTH = 0,
+  CSS_HEIGHT
+} css_dimension_t;
+
+typedef struct {
+  float position[4];
+  float dimensions[2];
+  css_direction_t direction;
+
+  // Instead of recomputing the entire layout every single time, we
+  // cache some information to break early when nothing changed
+  bool should_update;
+  float last_requested_dimensions[2];
+  float last_parent_max_width;
+  float last_dimensions[2];
+  float last_position[2];
+  css_direction_t last_direction;
+} css_layout_t;
+
+typedef struct {
+  float dimensions[2];
+} css_dim_t;
+
+typedef struct {
+  css_direction_t direction;
+  css_flex_direction_t flex_direction;
+  css_justify_t justify_content;
+  css_align_t align_content;
+  css_align_t align_items;
+  css_align_t align_self;
+  css_position_type_t position_type;
+  css_wrap_type_t flex_wrap;
+  float flex;
+  float margin[6];
+  float position[4];
+  /**
+   * You should skip all the rules that contain negative values for the
+   * following attributes. For example:
+   *   {padding: 10, paddingLeft: -5}
+   * should output:
+   *   {left: 10 ...}
+   * the following two are incorrect:
+   *   {left: -5 ...}
+   *   {left: 0 ...}
+   */
+  float padding[6];
+  float border[6];
+  float dimensions[2];
+  float minDimensions[2];
+  float maxDimensions[2];
+} css_style_t;
+
+typedef struct css_node {
+  css_style_t style;
+  css_layout_t layout;
+  int children_count;
+  int line_index;
+
+  css_dim_t (*measure)(void *context, float width);
+  void (*print)(void *context);
+  struct css_node* (*get_child)(void *context, int i);
+  bool (*is_dirty)(void *context);
+  void *context;
+} css_node_t;
+
+
+// Lifecycle of nodes and children
+css_node_t *new_css_node(void);
+void init_css_node(css_node_t *node);
+void free_css_node(css_node_t *node);
+
+// Print utilities
+typedef enum {
+  CSS_PRINT_LAYOUT = 1,
+  CSS_PRINT_STYLE = 2,
+  CSS_PRINT_CHILDREN = 4,
+} css_print_options_t;
+void print_css_node(css_node_t *node, css_print_options_t options);
+
+// Function that computes the layout!
+void layoutNode(css_node_t *node, float maxWidth, css_direction_t parentDirection);
+bool isUndefined(float value);
+
+#endif
+
+#ifdef CSS_LAYOUT_IMPLEMENTATION
 /**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
@@ -1142,3 +1311,5 @@ void layoutNode(css_node_t *node, float parentMaxWidth, css_direction_t parentDi
     layout->last_position[CSS_LEFT] = layout->position[CSS_LEFT];
   }
 }
+
+#endif // CSS_LAYOUT_IMPLEMENTATION

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-eslint": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-execute": "^0.2.2",
     "grunt-include-replace": "^3.1.0",
     "grunt-karma": "^0.12.0",
+    "grunt-mkdir": "^0.1.2",
     "grunt-shell": "^1.1.2",
     "jasmine-core": "^2.2.0",
     "karma": "^0.13.8",


### PR DESCRIPTION
All tested on Windows and OSX.

The package-c task creates a unified css-layout.h file which is a single include containing the header and the implementation.

Example usage:
```c
// some_file.c
#define CSS_LAYOUT_IMPLEMENTATION
#include <css-layout.h> // prototypes and implementation
...
```

```c
// some_other_file.c
#include <css-layout.h> // prototypes only
```

This in my experience is the simplest way to distribute a lightweight C lib, its inspired by https://github.com/nothings/stb.