### PR TITLE
Added npm deploy when tags are pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,12 @@ addons:
   apt:
     packages:
       - gcc
+
+deploy:
+  provider: npm
+  email: ceberhardt@scottlogic.com
+  api_key:
+    secure: Vc9fsS/InXhvF8b3OIK5iTCRRB4ajUP73E5ObLiFYskVTCb5tLbl8rdYElV/uE2LF3Dw3SE9OyAARFPtkbUcmJ3A6YibEx5eKlPjWJZ8P0Pe85ap9XjopZzHzqpu+8kvZIPIQKUyisrD6RCRQdudT2uZKg2jvyvRwjnNVlVye4M=
+  on:
+    tags: true
+    branch: master


### PR DESCRIPTION
With this configuration update a new package will automatically be deployed to npm when the repo is tagged. When this is merged I'd like to propose tagging and releasing v1.0.0 

(css-layout is at 0.0.2, the recent changes were breaking, hence 1.0.0 under semver).

@chrisprice can you quickly double check my travis config? it all looks pretty straightforward, but wanted to check based on your prior experience!

closes #101 