### PR TITLE
Watch for changes and run tests during development using `grunt watch`.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,12 @@ module.exports = function(grunt) {
       javaPackage: {
         command: 'jar cf <%= config.distFolder %>/<%= config.libName %>.jar <%= config.javaSource %>'
       }
-    }
+    },
+
+    watch: {
+      files: ['src/Layout.js'],
+      tasks: ['ci'],
+    },
   });
 
   // Compiles and runs the Java tests

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Reimplementation of CSS layout using pure JavaScript",
   "main": "dist/css-layout.js",
   "scripts": {
+    "watch": "grunt watch",
     "test": "grunt ci",
     "postversion": "git push --tags upstream HEAD:master"
   },
@@ -24,6 +25,7 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-uglify": "^0.9.1",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^17.1.0",
     "grunt-execute": "^0.2.2",
     "grunt-include-replace": "^3.1.0",


### PR DESCRIPTION
In development, watch for changes to `src/Layout.js` and keep running tests whenever the file changes. Helps to ensure that a breaking change is not introduced while developing.