### PR TITLE
Supress warning about incorrect license SPDX type

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "layout"
   ],
   "author": "",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/facebook/css-layout/issues"
   },

--- a/src/csharp/CSSLayout/CSSLayout.sln
+++ b/src/csharp/CSSLayout/CSSLayout.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSSLayout", "CSSLayout\CSSLayout.csproj", "{FA76359A-30D2-4E36-91CE-ACEE373D8396}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSSLayoutTests", "CSSLayoutTests\CSSLayoutTests.csproj", "{084B83DB-0772-4534-BF69-95E696834AE0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{084B83DB-0772-4534-BF69-95E696834AE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{084B83DB-0772-4534-BF69-95E696834AE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{084B83DB-0772-4534-BF69-95E696834AE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{084B83DB-0772-4534-BF69-95E696834AE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA76359A-30D2-4E36-91CE-ACEE373D8396}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA76359A-30D2-4E36-91CE-ACEE373D8396}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA76359A-30D2-4E36-91CE-ACEE373D8396}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA76359A-30D2-4E36-91CE-ACEE373D8396}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/csharp/CSSLayout/CSSLayout/ArrayUtils.cs
+++ b/src/csharp/CSSLayout/CSSLayout/ArrayUtils.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class ArrayExtensions
+	{
+		public static void Fill<T> (T[] array, T value) where T : struct
+		{
+			if (array == null) {
+				throw new ArgumentNullException ("array");
+			}
+
+			for (int i = 0; i < array.Length; i++) {
+				array [i] = value;
+			}
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSAlign.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSAlign.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public enum CSSAlign
+	{
+		AUTO,
+		FLEX_START,
+		CENTER,
+		FLEX_END,
+		STRETCH
+	}
+}

--- a/src/csharp/CSSLayout/CSSLayout/CSSConstants.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSConstants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class CSSConstants
+	{
+		public CSSConstants ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSDirection.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSDirection.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public enum CSSDirection
+	{
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSFlexDirection.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSFlexDirection.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public enum CSSFlexDirection
+	{
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSJustify.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSJustify.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public enum CSSJustify
+	{
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSLayout.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSLayout.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class CSSLayout
+	{
+		public CSSLayout ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSLayout.csproj
+++ b/src/csharp/CSSLayout/CSSLayout/CSSLayout.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{FA76359A-30D2-4E36-91CE-ACEE373D8396}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>CSSLayout</RootNamespace>
+    <AssemblyName>CSSLayout</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CachedCSSLayout.cs" />
+    <Compile Include="CSSAlign.cs" />
+    <Compile Include="CSSConstants.cs" />
+    <Compile Include="CSSDirection.cs" />
+    <Compile Include="CSSFlexDirection.cs" />
+    <Compile Include="CSSJustify.cs" />
+    <Compile Include="CSSLayout.cs" />
+    <Compile Include="CSSLayoutContext.cs" />
+    <Compile Include="MeasureOutput.cs" />
+    <Compile Include="CSSNode.cs" />
+    <Compile Include="CSSStyle.cs" />
+    <Compile Include="Spacing.cs" />
+    <Compile Include="CSSWrap.cs" />
+    <Compile Include="FloatUtils.cs" />
+    <Compile Include="CSSPositionType.cs" />
+    <Compile Include="LayoutEngine.cs" />
+    <Compile Include="IMeasureFunction.cs" />
+    <Compile Include="ArrayUtils.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>

--- a/src/csharp/CSSLayout/CSSLayout/CSSLayoutContext.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSLayoutContext.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class CSSLayoutContext
+	{
+		public CSSLayoutContext ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSNode.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSNode.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class CSSNode
+	{
+		public CSSNode ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSPositionType.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSPositionType.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public enum CSSPositionType
+	{
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSStyle.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSStyle.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class CSSStyle
+	{
+		public CSSStyle ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CSSWrap.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CSSWrap.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public enum CSSWrap
+	{
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/CachedCSSLayout.cs
+++ b/src/csharp/CSSLayout/CSSLayout/CachedCSSLayout.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class CachedCSSLayout
+	{
+		public CachedCSSLayout ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/FloatUtils.cs
+++ b/src/csharp/CSSLayout/CSSLayout/FloatUtils.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class FloatUtils
+	{
+		public FloatUtils ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/IMeasureFunction.cs
+++ b/src/csharp/CSSLayout/CSSLayout/IMeasureFunction.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public interface IMeasureFunction
+	{
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/LayoutEngine.cs
+++ b/src/csharp/CSSLayout/CSSLayout/LayoutEngine.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class LayoutEngine
+	{
+		public LayoutEngine ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/MeasureOutput.cs
+++ b/src/csharp/CSSLayout/CSSLayout/MeasureOutput.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class MeasureOutput
+	{
+		public MeasureOutput ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayout/Spacing.cs
+++ b/src/csharp/CSSLayout/CSSLayout/Spacing.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CSSLayout
+{
+	public class Spacing
+	{
+		public Spacing ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayoutTests/CSSLayoutTests.csproj
+++ b/src/csharp/CSSLayout/CSSLayoutTests/CSSLayoutTests.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{084B83DB-0772-4534-BF69-95E696834AE0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>CSSLayoutTests</RootNamespace>
+    <AssemblyName>CSSLayoutTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/csharp/CSSLayout/CSSLayoutTests/Test.cs
+++ b/src/csharp/CSSLayout/CSSLayoutTests/Test.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace CSSLayoutTests
+{
+	[TestFixture ()]
+	public class Test
+	{
+		[Test ()]
+		public void TestCase ()
+		{
+		}
+	}
+}
+

--- a/src/csharp/CSSLayout/CSSLayoutTests/packages.config
+++ b/src/csharp/CSSLayout/CSSLayoutTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Added correct SPDX license type in order to get rid of the warning NPM was throwing each invocation