### PR TITLE
Implement caching in the JS version

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1128,9 +1128,10 @@ var computeLayout = (function() {
          node.lastLayout.requestedHeight !== node.layout.height ||
          node.lastLayout.requestedWidth !== node.layout.width ||
          node.lastLayout.parentMaxWidth !== parentMaxWidth) {
-      
-      if (!node.lastLayout)
+           
+      if (!node.lastLayout) {
         node.lastLayout = {};
+      }
       
       node.lastLayout.requestedWidth = node.layout.width;
       node.lastLayout.requestedHeight = node.layout.height;
@@ -1138,11 +1139,13 @@ var computeLayout = (function() {
     
       layoutNodeImpl(node, parentMaxWidth, parentDirection);
       
-      for (var key in node.layout)
+      for (var key in node.layout) {
         node.lastLayout[key] = node.layout[key];
+      }
     } else {
-      for (var key in node.layout)
+      for (var key in node.layout) {
         node.layout[key] = node.lastLayout[key];
+      }
     }
   }
 

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1124,12 +1124,23 @@ var computeLayout = (function() {
   }
   
   function layoutNode(node, parentMaxWidth, parentDirection) {
-    if (node.isDirty ||
-        !node.lastLayout || 
-         node.lastLayout.requestedHeight !== node.layout.height ||
-         node.lastLayout.requestedWidth !== node.layout.width ||
-         node.lastLayout.parentMaxWidth !== parentMaxWidth) {
-           
+    node.shouldUpdate = true;
+    
+    var direction = node.style.direction || CSS_DIRECTION_LTR;
+    var skipLayout = 
+      !node.isDirty &&
+      node.lastLayout &&
+      node.lastLayout.requestedHeight === node.layout.height &&
+      node.lastLayout.requestedWidth === node.layout.width &&
+      node.lastLayout.parentMaxWidth === parentMaxWidth &&
+      node.lastLayout.direction === direction;
+      
+    if (skipLayout) {
+      node.layout.width = node.lastLayout.width;
+      node.layout.height = node.lastLayout.height;
+      node.layout.top = node.lastLayout.top;
+      node.layout.left = node.lastLayout.left;
+    } else {
       if (!node.lastLayout) {
         node.lastLayout = {};
       }
@@ -1137,6 +1148,7 @@ var computeLayout = (function() {
       node.lastLayout.requestedWidth = node.layout.width;
       node.lastLayout.requestedHeight = node.layout.height;
       node.lastLayout.parentMaxWidth = parentMaxWidth;
+      node.lastLayout.direction = direction;
       
       // Reset child layouts
       node.children.forEach(function(child) {
@@ -1144,24 +1156,15 @@ var computeLayout = (function() {
         child.layout.height = undefined;
         child.layout.top = 0;
         child.layout.left = 0;
-        child.layout.bottom = 0;
-        child.layout.right = 0;
       });
       
       layoutNodeImpl(node, parentMaxWidth, parentDirection);
       
-      for (var key in node.layout) {
-        node.lastLayout[key] = node.layout[key];
-      }
-      
-      node.isDirty = false;
-    } else {
-      for (var key in node.layout) {
-        node.layout[key] = node.lastLayout[key];
-      }
+      node.lastLayout.width = node.layout.width;
+      node.lastLayout.height = node.layout.height;
+      node.lastLayout.top = node.layout.top;
+      node.lastLayout.left = node.layout.left;
     }
-    
-    node.shouldUpdate = true;
   }
 
   return {

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1160,6 +1160,8 @@ var computeLayout = (function() {
         node.layout[key] = node.lastLayout[key];
       }
     }
+    
+    node.shouldUpdate = true;
   }
 
   return {

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -63,7 +63,7 @@ var computeLayout = (function() {
   // properties. For the JavaScript version this function adds these properties
   // if they don't already exist.
   function fillNodes(node) {
-    if (!node.layout) {
+    if (!node.layout || node.isDirty) {
       node.layout = {
         width: undefined,
         height: undefined,
@@ -1124,7 +1124,8 @@ var computeLayout = (function() {
   }
   
   function layoutNode(node, parentMaxWidth, parentDirection) {
-    if (!node.lastLayout ||
+    if (node.isDirty ||
+        !node.lastLayout || 
          node.lastLayout.requestedHeight !== node.layout.height ||
          node.lastLayout.requestedWidth !== node.layout.width ||
          node.lastLayout.parentMaxWidth !== parentMaxWidth) {
@@ -1136,12 +1137,24 @@ var computeLayout = (function() {
       node.lastLayout.requestedWidth = node.layout.width;
       node.lastLayout.requestedHeight = node.layout.height;
       node.lastLayout.parentMaxWidth = parentMaxWidth;
-    
+      
+      // Reset child layouts
+      node.children.forEach(function(child) {
+        child.layout.width = undefined;
+        child.layout.height = undefined;
+        child.layout.top = 0;
+        child.layout.left = 0;
+        child.layout.bottom = 0;
+        child.layout.right = 0;
+      });
+      
       layoutNodeImpl(node, parentMaxWidth, parentDirection);
       
       for (var key in node.layout) {
         node.lastLayout[key] = node.layout[key];
       }
+      
+      node.isDirty = false;
     } else {
       for (var key in node.layout) {
         node.layout[key] = node.lastLayout[key];

--- a/src/transpile.js
+++ b/src/transpile.js
@@ -8,7 +8,7 @@
  */
 
 var layoutTestUtils = require('./Layout-test-utils.js');
-var computeLayout = require('./Layout.js').computeLayout;
+var computeLayout = require('./Layout.js').layoutNodeImpl;
 var fs = require('fs');
 var JavaTranspiler = require('./JavaTranspiler.js');
 var CSharpTranspiler = require('./CSharpTranspiler.js');


### PR DESCRIPTION
This implements caching for the JS version, as suggested by @vjeux in #137. Here's the results of the same benchmark I used before, compared to the current master (after my previous optimizations):

```
new x 270 ops/sec ±122.16% (94 runs sampled)
old x 22.76 ops/sec ±4.21% (43 runs sampled)
new is the fastest
old is 92% slower
```