### PR TITLE
Add reset() method to CSSNode

### DIFF
--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -400,4 +400,19 @@ public class CSSNode {
       dirty();
     }
   }
+
+  /**
+   * Resets this instance to its default state. This method is meant to be used when
+   * recycling {@link CSSNode} instances.
+   */
+  public void reset() {
+    if (mParent != null || (mChildren != null && mChildren.size() > 0)) {
+      throw new IllegalStateException("You should not reset an attached CSSNode");
+    }
+
+    style.reset();
+    layout.resetResult();
+    lineIndex = 0;
+    mLayoutState = LayoutState.DIRTY;
+  }
 }

--- a/src/java/src/com/facebook/csslayout/CSSStyle.java
+++ b/src/java/src/com/facebook/csslayout/CSSStyle.java
@@ -8,40 +8,62 @@
  */
 package com.facebook.csslayout;
 
+import java.util.Arrays;
+
 /**
  * The CSS style definition for a {@link CSSNode}.
  */
 public class CSSStyle {
 
-  public CSSDirection direction = CSSDirection.INHERIT;
-  public CSSFlexDirection flexDirection = CSSFlexDirection.COLUMN;
-  public CSSJustify justifyContent = CSSJustify.FLEX_START;
-  public CSSAlign alignContent = CSSAlign.FLEX_START;
-  public CSSAlign alignItems = CSSAlign.STRETCH;
-  public CSSAlign alignSelf = CSSAlign.AUTO;
-  public CSSPositionType positionType = CSSPositionType.RELATIVE;
-  public CSSWrap flexWrap = CSSWrap.NOWRAP;
+  public CSSDirection direction;
+  public CSSFlexDirection flexDirection;
+  public CSSJustify justifyContent;
+  public CSSAlign alignContent;
+  public CSSAlign alignItems;
+  public CSSAlign alignSelf;
+  public CSSPositionType positionType;
+  public CSSWrap flexWrap;
   public float flex;
 
   public Spacing margin = new Spacing();
   public Spacing padding = new Spacing();
   public Spacing border = new Spacing();
 
-  public float[] position = {
-      CSSConstants.UNDEFINED,
-      CSSConstants.UNDEFINED,
-      CSSConstants.UNDEFINED,
-      CSSConstants.UNDEFINED,
-  };
-
-  public float[] dimensions = {
-      CSSConstants.UNDEFINED,
-      CSSConstants.UNDEFINED,
-  };
+  public float[] position = new float[4];
+  public float[] dimensions = new float[2];
 
   public float minWidth = CSSConstants.UNDEFINED;
   public float minHeight = CSSConstants.UNDEFINED;
 
   public float maxWidth = CSSConstants.UNDEFINED;
   public float maxHeight = CSSConstants.UNDEFINED;
+
+  CSSStyle() {
+    reset();
+  }
+
+  void reset() {
+    direction = CSSDirection.INHERIT;
+    flexDirection = CSSFlexDirection.COLUMN;
+    justifyContent = CSSJustify.FLEX_START;
+    alignContent = CSSAlign.FLEX_START;
+    alignItems = CSSAlign.STRETCH;
+    alignSelf = CSSAlign.AUTO;
+    positionType = CSSPositionType.RELATIVE;
+    flexWrap = CSSWrap.NOWRAP;
+    flex = 0f;
+
+    margin.reset();;
+    padding.reset();
+    border.reset();
+
+    Arrays.fill(position, CSSConstants.UNDEFINED);
+    Arrays.fill(dimensions, CSSConstants.UNDEFINED);
+
+    minWidth = CSSConstants.UNDEFINED;
+    minHeight = CSSConstants.UNDEFINED;
+
+    maxWidth = CSSConstants.UNDEFINED;
+    maxHeight = CSSConstants.UNDEFINED;
+  }
 }

--- a/src/java/src/com/facebook/csslayout/Spacing.java
+++ b/src/java/src/com/facebook/csslayout/Spacing.java
@@ -10,6 +10,8 @@ package com.facebook.csslayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+
 /**
  * Class representing CSS spacing (padding, margin, and borders). This is mostly necessary to
  * properly implement interactions and updates for properties like margin, marginLeft, and
@@ -159,6 +161,17 @@ public class Spacing {
    */
   public float getRaw(int spacingType) {
     return mSpacing[spacingType];
+  }
+
+  /**
+   * Resets the spacing instance to its default state. This method is meant to be used when
+   * recycling {@link Spacing} instances.
+   */
+  void reset() {
+    Arrays.fill(mSpacing, CSSConstants.UNDEFINED);
+    mDefaultSpacing = null;
+    mHasAliasesSet = false;
+    mValueFlags = 0;
   }
 
   /**


### PR DESCRIPTION
This allows users of css-layout in Java to perform faster resets on
CSSNode in cases when you want to recycle instances.

CSSLayout.resetResult() was renamed to simply reset() for consistency.