### PR TITLE
Faster enum comparisons in CSSNode

### DIFF
--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -115,7 +115,7 @@ public class CSSNode {
   }
 
   public void setMeasureFunction(MeasureFunction measureFunction) {
-    if (!valuesEqual(mMeasureFunction, measureFunction)) {
+    if (mMeasureFunction != measureFunction) {
       mMeasureFunction = measureFunction;
       dirty();
     }
@@ -221,57 +221,50 @@ public class CSSNode {
     return FloatUtil.floatsEqual(f1, f2);
   }
 
-  protected <T> boolean valuesEqual(@Nullable T o1, @Nullable T o2) {
-    if (o1 == null) {
-      return o2 == null;
-    }
-    return o1.equals(o2);
-  }
-
   public void setDirection(CSSDirection direction) {
-    if (!valuesEqual(style.direction, direction)) {
+    if (style.direction != direction) {
       style.direction = direction;
       dirty();
     }
   }
 
   public void setFlexDirection(CSSFlexDirection flexDirection) {
-    if (!valuesEqual(style.flexDirection, flexDirection)) {
+    if (style.flexDirection != flexDirection) {
       style.flexDirection = flexDirection;
       dirty();
     }
   }
 
   public void setJustifyContent(CSSJustify justifyContent) {
-    if (!valuesEqual(style.justifyContent, justifyContent)) {
+    if (style.justifyContent != justifyContent) {
       style.justifyContent = justifyContent;
       dirty();
     }
   }
 
   public void setAlignItems(CSSAlign alignItems) {
-    if (!valuesEqual(style.alignItems, alignItems)) {
+    if (style.alignItems != alignItems) {
       style.alignItems = alignItems;
       dirty();
     }
   }
 
   public void setAlignSelf(CSSAlign alignSelf) {
-    if (!valuesEqual(style.alignSelf, alignSelf)) {
+    if (style.alignSelf != alignSelf) {
       style.alignSelf = alignSelf;
       dirty();
     }
   }
 
   public void setPositionType(CSSPositionType positionType) {
-    if (!valuesEqual(style.positionType, positionType)) {
+    if (style.positionType != positionType) {
       style.positionType = positionType;
       dirty();
     }
   }
 
   public void setWrap(CSSWrap flexWrap) {
-    if (!valuesEqual(style.flexWrap, flexWrap)) {
+    if (style.flexWrap != flexWrap) {
       style.flexWrap = flexWrap;
       dirty();
     }


### PR DESCRIPTION
Enums are singletons by design so it's safe (and faster) to compare by
reference. This also covers the null case.