### PR TITLE
return correct value from Width property (C#)

### DIFF
--- a/src/csharp/Facebook.CSSLayout/CSSNode.cs
+++ b/src/csharp/Facebook.CSSLayout/CSSNode.cs
@@ -380,7 +380,7 @@ namespace Facebook.CSSLayout
         public float Width
         {
             get { return style.dimensions[DIMENSION_WIDTH]; }
-            set { updateFloatValue(ref style.dimensions[DIMENSION_HEIGHT], value); }
+            set { updateFloatValue(ref style.dimensions[DIMENSION_WIDTH], value); }
         }
 
         public float Height


### PR DESCRIPTION
`CSSNode.Width` returns the wrong value. It returns `DIMENSION_HEIGHT` instead of `DIMENSION_WIDTH`.