### PR TITLE
New style getters and cleanups in CSSNode

### DIFF
--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -228,11 +228,25 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's flex direction, as defined by style.
+   */
+  public CSSFlexDirection getFlexDirection() {
+    return style.flexDirection;
+  }
+
   public void setFlexDirection(CSSFlexDirection flexDirection) {
     if (style.flexDirection != flexDirection) {
       style.flexDirection = flexDirection;
       dirty();
     }
+  }
+
+  /**
+   * Get this node's justify content, as defined by style.
+   */
+  public CSSJustify getJustifyContent() {
+    return style.justifyContent;
   }
 
   public void setJustifyContent(CSSJustify justifyContent) {
@@ -242,6 +256,13 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's align items, as defined by style.
+   */
+  public CSSAlign getAlignItems() {
+    return style.alignItems;
+  }
+
   public void setAlignItems(CSSAlign alignItems) {
     if (style.alignItems != alignItems) {
       style.alignItems = alignItems;
@@ -249,11 +270,25 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's align items, as defined by style.
+   */
+  public CSSAlign getAlignSelf() {
+    return style.alignSelf;
+  }
+
   public void setAlignSelf(CSSAlign alignSelf) {
     if (style.alignSelf != alignSelf) {
       style.alignSelf = alignSelf;
       dirty();
     }
+  }
+
+  /**
+   * Get this node's position type, as defined by style.
+   */
+  public CSSPositionType getPositionType() {
+    return style.positionType;
   }
 
   public void setPositionType(CSSPositionType positionType) {
@@ -270,11 +305,25 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's flex, as defined by style.
+   */
+  public float getFlex() {
+    return style.flex;
+  }
+
   public void setFlex(float flex) {
     if (!valuesEqual(style.flex, flex)) {
       style.flex = flex;
       dirty();
     }
+  }
+
+  /**
+   * Get this node's margin, as defined by style + default margin.
+   */
+  public Spacing getMargin() {
+    return style.margin;
   }
 
   public void setMargin(int spacingType, float margin) {
@@ -289,10 +338,24 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's border, as defined by style.
+   */
+  public Spacing getBorder() {
+    return style.border;
+  }
+
   public void setBorder(int spacingType, float border) {
     if (style.border.set(spacingType, border)) {
       dirty();
     }
+  }
+
+  /**
+   * Get this node's position top, as defined by style.
+   */
+  public float getPositionTop() {
+    return style.position[POSITION_TOP];
   }
 
   public void setPositionTop(float positionTop) {
@@ -302,6 +365,13 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's position bottom, as defined by style.
+   */
+  public float getPositionBottom() {
+    return style.position[POSITION_BOTTOM];
+  }
+
   public void setPositionBottom(float positionBottom) {
     if (!valuesEqual(style.position[POSITION_BOTTOM], positionBottom)) {
       style.position[POSITION_BOTTOM] = positionBottom;
@@ -309,11 +379,25 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's position left, as defined by style.
+   */
+  public float getPositionLeft() {
+    return style.position[POSITION_LEFT];
+  }
+
   public void setPositionLeft(float positionLeft) {
     if (!valuesEqual(style.position[POSITION_LEFT], positionLeft)) {
       style.position[POSITION_LEFT] = positionLeft;
       dirty();
     }
+  }
+
+  /**
+   * Get this node's position right, as defined by style.
+   */
+  public float getPositionRight() {
+    return style.position[POSITION_RIGHT];
   }
 
   public void setPositionRight(float positionRight) {

--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -221,6 +221,13 @@ public class CSSNode {
     return FloatUtil.floatsEqual(f1, f2);
   }
 
+  /**
+   * Get this node's direction, as defined in the style.
+   */
+  public CSSDirection getStyleDirection() {
+    return style.direction;
+  }
+
   public void setDirection(CSSDirection direction) {
     if (style.direction != direction) {
       style.direction = direction;
@@ -332,6 +339,13 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's padding, as defined by style + default padding.
+   */
+  public Spacing getPadding() {
+    return style.padding;
+  }
+
   public void setPadding(int spacingType, float padding) {
     if (style.padding.set(spacingType, padding)) {
       dirty();
@@ -407,11 +421,25 @@ public class CSSNode {
     }
   }
 
+  /**
+   * Get this node's width, as defined in the style.
+   */
+  public float getStyleWidth() {
+    return style.dimensions[DIMENSION_WIDTH];
+  }
+
   public void setStyleWidth(float width) {
     if (!valuesEqual(style.dimensions[DIMENSION_WIDTH], width)) {
       style.dimensions[DIMENSION_WIDTH] = width;
       dirty();
     }
+  }
+
+  /**
+   * Get this node's height, as defined in the style.
+   */
+  public float getStyleHeight() {
+    return style.dimensions[DIMENSION_HEIGHT];
   }
 
   public void setStyleHeight(float height) {
@@ -439,34 +467,6 @@ public class CSSNode {
 
   public CSSDirection getLayoutDirection() {
     return layout.direction;
-  }
-
-  /**
-   * Get this node's padding, as defined by style + default padding.
-   */
-  public Spacing getStylePadding() {
-    return style.padding;
-  }
-
-  /**
-   * Get this node's width, as defined in the style.
-   */
-  public float getStyleWidth() {
-    return style.dimensions[DIMENSION_WIDTH];
-  }
-
-  /**
-   * Get this node's height, as defined in the style.
-   */
-  public float getStyleHeight() {
-    return style.dimensions[DIMENSION_HEIGHT];
-  }
-
-  /**
-   * Get this node's direction, as defined in the style.
-   */
-  public CSSDirection getStyleDirection() {
-    return style.direction;
   }
 
   /**


### PR DESCRIPTION
This PR adds all missing getters for style properties in CSSNode for consistency and because now we have some use cases for it.

Furthermore, I've renamed the existing getters and some setters to follow a more consistent pattern. This involves an API break so I'm considering this part kinda optional (even though I really think we should do it).

Having "Style" in the method names seems redundant given that we currently have setters that implicitly set style and don't have "style" in their name. For example, we have `setPadding()` but the getter is called `getStylePadding()`. We should be more consistent about this.

The following methods are renamed:
* getStyleWidth() -> getWidth()
* getStyleHeight() -> getHeight()
* setStyleWidth() -> setWidth()
* setStyleHeight() -> setHeight()
* getStyleDirection() -> getDirection()
* getStylePadding() -> getPadding()

With these changes, the CSSNode API will be more like "all setters/getters members affect style, unless they "Layout" in their name, which sounds simpler and more consistent.