### PR TITLE
Configure travis to install mono and run the C# tests from within the…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@ language: node_js
 node_js:
   - "0.12"
 
-sudo: false
+sudo: true
 
 before_install:
   - npm install grunt-cli -g
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+  - echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+  - echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install mono-devel referenceassemblies-pcl nunit
 
 addons:
   apt:
     packages:
       - gcc
-      

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,6 +145,12 @@ module.exports = function(grunt) {
       },
       javaPackage: {
         command: 'jar cf <%= config.distFolder %>/<%= config.libName %>.jar <%= config.javaSource %>'
+      },
+      csharpCompile: {
+        command: 'xbuild /verbosity:m /nologo src/csharp/Facebook.CSSLayout.sln /p:Configuration=Release /t:"Facebook_CSSLayout:Rebuild;Facebook_CSSLayout_Tests:Rebuild"'
+      },
+      csharpTestExecute: {
+        command: 'nunit-console -nologo src/csharp/Facebook.CSSLayout.Tests/bin/Release/Facebook.CSSLayout.Tests.dll'   
       }
     },
 
@@ -157,11 +163,14 @@ module.exports = function(grunt) {
   // Compiles and runs the Java tests
   grunt.registerTask('test-java', ['shell:javaCompile', 'shell:javaTestExecute', 'clean:javaTest']);
 
+  // Compiles and runs the CSharp tests
+  grunt.registerTask('test-csharp', ['shell:csharpCompile', 'shell:csharpTestExecute']);
+
   // Compiles and runs the C tests
   grunt.registerTask('test-c', ['shell:cCompile', 'shell:cTestExecute', 'clean:cTest']);
 
   // Transpiles the JavaScript to C and Java, running tests
-  grunt.registerTask('transpile', ['execute:transpile', 'test-c', 'test-java']);
+  grunt.registerTask('transpile', ['execute:transpile', 'test-c', 'test-java', 'test-csharp']);
 
   // Lints and tests the JavaScritp using Chrome
   grunt.registerTask('test-javascript', ['eslint', 'karma']);


### PR DESCRIPTION
… Gruntfile

This PR shows my first attempt to automatically build and run the C# tests with travis (#142), but reverts to the legacy infrastructure of travis-ci, because it requires sudo support. The primary reason is that the packages `referenceassemblies-pcl` and `nunit` are not whitelisted yet.