### PR TITLE
Need dirty() to be virtual to override in special cases.

### DIFF
--- a/src/csharp/Facebook.CSSLayout/CSSConstants.cs
+++ b/src/csharp/Facebook.CSSLayout/CSSConstants.cs
@@ -11,7 +11,7 @@ namespace Facebook.CSSLayout
 {
     public static class CSSConstants 
     {
-        public static readonly float Undefined = float.NaN;
+        public const float Undefined = float.NaN;
 
         public static bool IsUndefined(float value) 
         {

--- a/src/csharp/Facebook.CSSLayout/CSSNode.cs
+++ b/src/csharp/Facebook.CSSLayout/CSSNode.cs
@@ -179,7 +179,7 @@ namespace Facebook.CSSLayout
             get { return mLayoutState == LayoutState.HAS_NEW_LAYOUT; }
         }
 
-        internal protected void dirty()
+        internal protected virtual void dirty()
         {
             if (mLayoutState == LayoutState.DIRTY)
             {


### PR DESCRIPTION
See, for example ReactShadowNode in the ReactAndroid code base, which overrides this virtual.