### PR TITLE
Allow passing a layout direction to calculateLayout

### DIFF
--- a/src/csharp/Facebook.CSSLayout/CSSNode.cs
+++ b/src/csharp/Facebook.CSSLayout/CSSNode.cs
@@ -155,8 +155,13 @@ namespace Facebook.CSSLayout
 
         public void CalculateLayout()
         {
+            CalculateLayout(null);
+        }
+
+        public void CalculateLayout(CSSDirection? direction)
+        {
             layout.resetResult();
-            LayoutEngine.layoutNode(DummyLayoutContext, this, CSSConstants.Undefined, CSSConstants.Undefined, null);
+            LayoutEngine.layoutNode(DummyLayoutContext, this, CSSConstants.Undefined, CSSConstants.Undefined, direction);
         }
 
         static readonly CSSLayoutContext DummyLayoutContext = new CSSLayoutContext();

--- a/src/java/src/com/facebook/csslayout/CSSNode.java
+++ b/src/java/src/com/facebook/csslayout/CSSNode.java
@@ -139,8 +139,15 @@ public class CSSNode {
    * Performs the actual layout and saves the results in {@link #layout}
    */
   public void calculateLayout(CSSLayoutContext layoutContext) {
+    calculateLayout(layoutContext, null);
+  }
+
+  /**
+   * Performs the actual layout and saves the results in {@link #layout}
+   */
+  public void calculateLayout(CSSLayoutContext layoutContext, CSSDirection direction) {
     layout.resetResult();
-    LayoutEngine.layoutNode(layoutContext, this, CSSConstants.UNDEFINED, CSSConstants.UNDEFINED, null);
+    LayoutEngine.layoutNode(layoutContext, this, CSSConstants.UNDEFINED, CSSConstants.UNDEFINED, direction);
   }
 
   /**


### PR DESCRIPTION
This allows user of the java and csharp api to pass a direction with which to calculate the root of the tree. Previously the direction defaulted to LTR and the rest of the tree was thus LTR. Making the tree RTL required wrapping the tree in a container node with explicit RTL direction.