### PR TITLE
:rocket: fix P/Invoke sig for bool

### DIFF
--- a/csharp/Facebook.CSSLayout/CSSNode.cs
+++ b/csharp/Facebook.CSSLayout/CSSNode.cs
@@ -54,6 +54,9 @@ namespace Facebook.CSSLayout
                 _isDisposed = true;
                 Native.CSSNodeFree(_cssNode);
                 GCHandle.FromIntPtr(_context).Free();
+                _children = null;
+                _parent = null;
+                _measureFunction = null;
             }
         }
 
@@ -68,11 +71,7 @@ namespace Facebook.CSSLayout
 
         public void Reset()
         {
-            Native.CSSNodeFree(_cssNode);
-            GCHandle.FromIntPtr(_context).Free();
-            _children = null;
-            _parent = null;
-            _measureFunction = null;
+            Dispose(true);
         }
 
         public bool IsDirty

--- a/csharp/Facebook.CSSLayout/Native.cs
+++ b/csharp/Facebook.CSSLayout/Native.cs
@@ -89,7 +89,6 @@ namespace Facebook.CSSLayout
 
         [DllImport(DllName)]
         [return: MarshalAs(UnmanagedType.I1)]
-
         public static extern bool CSSNodeGetHasNewLayout(IntPtr node);
 
         #endregion

--- a/csharp/Facebook.CSSLayout/Native.cs
+++ b/csharp/Facebook.CSSLayout/Native.cs
@@ -47,12 +47,14 @@ namespace Facebook.CSSLayout
         public static extern void CSSNodeMarkDirty(IntPtr node);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool CSSNodeIsDirty(IntPtr node);
 
         [DllImport(DllName)]
         public static extern void CSSNodePrint(IntPtr node, CSSPrintOptions options);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool CSSValueIsUndefined(float value);
 
         #region CSS_NODE_PROPERTY
@@ -76,15 +78,18 @@ namespace Facebook.CSSLayout
         public static extern CSSPrintFunc CSSNodeGePrintFunc(IntPtr node);
 
         [DllImport(DllName)]
-        public static extern void CSSNodeSetIsTextnode(IntPtr node, bool isTextNode);
+        public static extern void CSSNodeSetIsTextnode(IntPtr node, [MarshalAs(UnmanagedType.I1)] bool isTextNode);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool CSSNodeGetIsTextnode(IntPtr node);
 
         [DllImport(DllName)]
-        public static extern void CSSNodeSetHasNewLayout(IntPtr node, bool hasNewLayout);
+        public static extern void CSSNodeSetHasNewLayout(IntPtr node, [MarshalAs(UnmanagedType.I1)] bool hasNewLayout);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.I1)]
+
         public static extern bool CSSNodeGetHasNewLayout(IntPtr node);
 
         #endregion


### PR DESCRIPTION
Fixes the `bool` marshaling issue as describe on [MSDN](https://blogs.msdn.microsoft.com/jaredpar/2008/10/14/pinvoke-and-bool-or-should-i-say-bool/) so C# will now act properly.