### PR TITLE
Fix C# delegate calling conventions

### DIFF
--- a/csharp/Facebook.CSSLayout/CSSAssert.cs
+++ b/csharp/Facebook.CSSLayout/CSSAssert.cs
@@ -8,11 +8,13 @@
  */
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Facebook.CSSLayout
 {
     internal static class CSSAssert
     {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void FailFunc(string message);
 
         private static bool _assertInitialized;

--- a/csharp/Facebook.CSSLayout/CSSLogger.cs
+++ b/csharp/Facebook.CSSLayout/CSSLogger.cs
@@ -8,11 +8,13 @@
  */
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Facebook.CSSLayout
 {
     internal static class CSSLogger
     {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void Func(string message);
 
         private static bool _initialized;

--- a/csharp/Facebook.CSSLayout/CSSMeasureFunc.cs
+++ b/csharp/Facebook.CSSLayout/CSSMeasureFunc.cs
@@ -8,9 +8,11 @@
  */
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Facebook.CSSLayout
 {
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate CSSSize CSSMeasureFunc(
         IntPtr context, 
         float width,

--- a/csharp/Facebook.CSSLayout/Native.cs
+++ b/csharp/Facebook.CSSLayout/Native.cs
@@ -21,10 +21,12 @@ namespace Facebook.CSSLayout
 #endif
 
         [DllImport(DllName)]
-        public static extern void CSSInteropSetLogger(CSSLogger.Func func);
+        public static extern void CSSInteropSetLogger(
+            [MarshalAs(UnmanagedType.FunctionPtr)] CSSLogger.Func func);
 
         [DllImport(DllName)]
-        public static extern void CSSAssertSetFailFunc(CSSAssert.FailFunc func);
+        public static extern void CSSAssertSetFailFunc(
+            [MarshalAs(UnmanagedType.FunctionPtr)] CSSAssert.FailFunc func);
 
         [DllImport(DllName)]
         public static extern IntPtr CSSNodeNew();
@@ -79,9 +81,12 @@ namespace Facebook.CSSLayout
         public static extern IntPtr CSSNodeGetContext(IntPtr node);
 
         [DllImport(DllName)]
-        public static extern void CSSNodeSetMeasureFunc(IntPtr node, CSSMeasureFunc measureFunc);
+        public static extern void CSSNodeSetMeasureFunc(
+            IntPtr node,
+            [MarshalAs(UnmanagedType.FunctionPtr)] CSSMeasureFunc measureFunc);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.FunctionPtr)]
         public static extern CSSMeasureFunc CSSNodeGetMeasureFunc(IntPtr node);
 
         [DllImport(DllName)]


### PR DESCRIPTION
When using CSS-Layout in a C# UWP project in x86, by default the MSVC compiler defaults the delegate calling convention to cdecl, while .NET assumes that all delegates are declared using stdcall.  This causes a problem when invoking such as this error:

```
Run-Time Check Failure #0 - The value of ESP was not properly saved across 
a function call.  This is usually a result of calling a function declared with one 
calling convention with a function pointer declared with a different calling 
convention. 
```

This PR changes the calling convention in the C# code to reflect cdecl by using the `UnmanagedFunctionPointer` attribute and setting the calling convention to `CallingConvention.Cdecl`.

```csharp
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
  public delegate CSSSize CSSMeasureFunc(
        IntPtr context,
        float width,
        CSSMeasureMode widthMode,
        float height,
        CSSMeasureMode heightMode);
```

I have updated all calls as well to other functions.  In addition, I added the `MarshalAs(UnmanagedType.FunctionPointer)` attribute to the instances where we get/set delegates.

```csharp
[DllImport(DllName)]
public static extern void CSSNodeSetMeasureFunc(IntPtr node, [MarshalAs(UnmanagedType.FunctionPtr)] CSSMeasureFunc measureFunc);
```