### PR TITLE
Remove children from the end to prevent copying over

### DIFF
--- a/csharp/Facebook.CSSLayout/CSSNode.cs
+++ b/csharp/Facebook.CSSLayout/CSSNode.cs
@@ -486,7 +486,7 @@ namespace Facebook.CSSLayout
         {
             while (_children.Count > 0)
             {
-                RemoveAt(0);
+                RemoveAt(_children.Count-1);
             }
         }
 


### PR DESCRIPTION
This PR leads to removing the children from the end. [So we don't have the overhead of copying them to the front](https://github.com/facebook/css-layout/blob/dcaef7ecb0ba35a1132386e3a542fe5c7eb11fa5/CSSLayout/CSSNodeList.c#L62). 