### PR TITLE
Prevent array out of bound access

### DIFF
--- a/uikit/CSSLayout/UIView+CSSLayout.m
+++ b/uikit/CSSLayout/UIView+CSSLayout.m
@@ -250,7 +250,7 @@ static void _attachNodesRecursive(UIView *view) {
     // Add any children which were added since the last call to css_applyLayout
     for (NSUInteger i = 0; i < view.subviews.count; i++) {
       CSSNodeRef childNode = [view.subviews[i] cssNode];
-      if (CSSNodeGetChild(node, i) != childNode) {
+      if (CSSNodeChildCount(node) < i + 1 || CSSNodeGetChild(node, i) != childNode) {
         CSSNodeInsertChild(node, childNode, i);
       }
       _attachNodesRecursive(view.subviews[i]);


### PR DESCRIPTION
Even so the problem of #236 has been fixed via ced779b there is still a case where you have a out of bound array access of undefined behaviour. This PR prevents the out of bound access of the underlying c array. The out of bound access happens if you already have 4 subViews and add another one. Then you will access CSSNodeGetChild with 4 which points into uninitialized memory.