### PR TITLE
do not redefine isnan if already defined via math.h

### DIFF
--- a/CSSLayout/CSSLayout.c
+++ b/CSSLayout/CSSLayout.c
@@ -14,7 +14,9 @@
 
 #ifdef _MSC_VER
 #include <float.h>
+#ifndef isnan
 #define isnan _isnan
+#endif
 
 #ifndef __cplusplus
 #define inline __inline


### PR DESCRIPTION
```isnan``` is already defined in ```math.h``` (at least when using VS13) so there is no need to redefine it. it also is a nan for float and not for double opposed to ```_isnan```