### PR TITLE
use size_t instead of unsigned long

### DIFF
--- a/CSSLayout/CSSLayout.c
+++ b/CSSLayout/CSSLayout.c
@@ -2173,7 +2173,7 @@ bool gPrintSkips = false;
 static const char *spacer = "                                                            ";
 
 static const char *getSpacer(const unsigned long level) {
-  const unsigned long spacerLen = strlen(spacer);
+  const size_t spacerLen = strlen(spacer);
   if (level > spacerLen) {
     return &spacer[0];
   } else {


### PR DESCRIPTION
Use ```size_t```instead of ```unsinged long``` as this is the "offical" return type of ```strlen```. Is VS13 ```size_t``` is defined as ```unsigned long long``` which leads to a compiler warning.