### PR TITLE
Enable `-fPIC` for C library

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -20,7 +20,7 @@ GMOCK_OVERRIDE_FLAGS = [
   '-Wno-inconsistent-missing-override',
 ]
 
-COMPILER_FLAGS = BASE_COMPILER_FLAGS + ['-std=c11']
+COMPILER_FLAGS = BASE_COMPILER_FLAGS + ['-std=c11', '-fPIC']
 TEST_COMPILER_FLAGS = BASE_COMPILER_FLAGS + GMOCK_OVERRIDE_FLAGS + ['-std=c++11']
 
 cxx_library(


### PR DESCRIPTION
At least or x86_64 linux, it appears that you need position-independent
code is required in order to link against it. Otherwise you see errors
like this:

```
/usr/bin/ld: lib_sys.rlib(CSSLayout.c.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: lib_sys.rlib(CSSNodeList.c.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
```

If I understand it correctly, you don't strictly need PIC for static libraries, but as soon as you want to link *other* dynamically linked library into it, it is required - which makes logical sense to me. Let me know if you want to enable this by default or leave it up to the developers to enable this if needed.